### PR TITLE
Continue reading janno files after broken line

### DIFF
--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -19,7 +19,7 @@ library
     build-depends:      base >= 4.7 && < 5, sequence-formats, text, time, pipes-safe,
                         exceptions, pipes, bytestring, filepath, yaml, aeson, directory, parsec,
                         vector, foldl, pipes-ordered-zip, pipes-group, table-layout, lens-family,
-                        cassava
+                        cassava, pandoc-citeproc
     default-language:   Haskell2010
 
 executable poet

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -13,7 +13,8 @@ extra-source-files:  README.md,
                      CHANGELOG.md
 
 library
-    exposed-modules:    Poseidon.Package, Poseidon.CmdFStats, Poseidon.CmdList, Poseidon.CmdSummarise, Poseidon.Utils
+    exposed-modules:    Poseidon.Package, Poseidon.CmdFStats, Poseidon.CmdList, 
+                        Poseidon.CmdSummarise, Poseidon.CmdValidate, Poseidon.Utils
     hs-source-dirs:     src
     build-depends:      base >= 4.7 && < 5, sequence-formats, text, time, pipes-safe,
                         exceptions, pipes, bytestring, filepath, yaml, aeson, directory, parsec,

--- a/src-executables/Main.hs
+++ b/src-executables/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+import           Control.Applicative ((<|>))
 import           Poseidon.CmdFStats    (FStatSpec (..), FstatsOptions (..),
                                         JackknifeMode (..), fStatSpecParser,
                                         runFstats, runParser)
@@ -8,28 +9,7 @@ import           Poseidon.CmdList      (ListEntity (..), ListOptions (..),
 import           Poseidon.CmdSummarise (SummariseOptions(..), runSummarise)
 import           Poseidon.CmdValidate  (ValidateOptions(..), runValidate)
 import           Data.ByteString.Char8 (pack, splitWith)
-import Options.Applicative as OP
-    ( Alternative((<|>), many, some),
-      briefDesc,
-      command,
-      eitherReader,
-      flag',
-      help,
-      info,
-      long,
-      metavar,
-      option,
-      progDesc,
-      short,
-      str,
-      strOption,
-      subparser,
-      switch,
-      value,
-      execParser,
-      helper,
-      Parser,
-      ParserInfo )
+import qualified Options.Applicative as OP
 import           SequenceFormats.Utils (Chrom (..))
 import           Text.Read             (readEither)
 

--- a/src-executables/Main.hs
+++ b/src-executables/Main.hs
@@ -6,9 +6,30 @@ import           Poseidon.CmdFStats    (FStatSpec (..), FstatsOptions (..),
 import           Poseidon.CmdList      (ListEntity (..), ListOptions (..),
                                         runList)
 import           Poseidon.CmdSummarise (SummariseOptions(..), runSummarise)
-
+import           Poseidon.CmdValidate  (ValidateOptions(..), runValidate)
 import           Data.ByteString.Char8 (pack, splitWith)
-import           Options.Applicative   as OP
+import Options.Applicative as OP
+    ( Alternative((<|>), many, some),
+      briefDesc,
+      command,
+      eitherReader,
+      flag',
+      help,
+      info,
+      long,
+      metavar,
+      option,
+      progDesc,
+      short,
+      str,
+      strOption,
+      subparser,
+      switch,
+      value,
+      execParser,
+      helper,
+      Parser,
+      ParserInfo )
 import           SequenceFormats.Utils (Chrom (..))
 import           Text.Read             (readEither)
 
@@ -16,6 +37,7 @@ import           Text.Read             (readEither)
 data Options = CmdList ListOptions
     | CmdFstats FstatsOptions
     | CmdSummarise SummariseOptions
+    | CmdValidate ValidateOptions
 
 main :: IO ()
 main = do
@@ -24,6 +46,7 @@ main = do
         CmdList opts   -> runList opts
         CmdFstats opts -> runFstats opts
         CmdSummarise opts  -> runSummarise opts
+        CmdValidate opts  -> runValidate opts
 
 optParserInfo :: OP.ParserInfo Options
 optParserInfo = OP.info (OP.helper <*> optParser) (OP.briefDesc <>
@@ -34,7 +57,9 @@ optParser :: OP.Parser Options
 optParser = OP.subparser $
     OP.command "list" listOptInfo <>
     OP.command "fstats" fstatsOptInfo <>
-    OP.command "summarise" summariseOptInfo
+    OP.command "summarise" summariseOptInfo <>
+    OP.command "validate" validateOptInfo
+
   where
     listOptInfo = OP.info (OP.helper <*> (CmdList <$> listOptParser))
         (OP.progDesc "list: list packages, groups or individuals available in the specified packages")
@@ -42,6 +67,8 @@ optParser = OP.subparser $
         (OP.progDesc "fstat: running fstats")
     summariseOptInfo = OP.info (OP.helper <*> (CmdSummarise <$> summariseOptParser))
         (OP.progDesc "summarise: get an overview over the content of one or multiple packages")
+    validateOptInfo = OP.info (OP.helper <*> (CmdValidate <$> validateOptParser))
+        (OP.progDesc "validate: check one or multiple packages for structural correctness")
 
 listOptParser :: OP.Parser ListOptions
 listOptParser = ListOptions <$> parseBasePaths <*> parseListEntity <*> parseRawOutput
@@ -56,6 +83,9 @@ fstatsOptParser = FstatsOptions <$> parseBasePaths
 
 summariseOptParser :: OP.Parser SummariseOptions
 summariseOptParser = SummariseOptions <$> parseBasePaths
+
+validateOptParser :: OP.Parser ValidateOptions
+validateOptParser = ValidateOptions <$> parseBasePaths
 
 -- parseJannoPath :: OP.Parser FilePath
 -- parseJannoPath = OP.strOption

--- a/src/Poseidon/CmdSummarise.hs
+++ b/src/Poseidon/CmdSummarise.hs
@@ -25,7 +25,7 @@ runSummarise (SummariseOptions baseDirs) = do
     let jannoFiles = loadJannoFiles jannoFilePaths
     jannoSamples <- fmap concat jannoFiles
     -- show all parsing errors
-    print (E.lefts jannoSamples)
+    mapM_ (\x -> putStrLn $ show x) (E.lefts jannoSamples)
     -- show actual summary
     summarisePoseidonSamples (E.rights jannoSamples)
 

--- a/src/Poseidon/CmdSummarise.hs
+++ b/src/Poseidon/CmdSummarise.hs
@@ -9,6 +9,7 @@ import           Poseidon.Package   (loadPoseidonPackages,
 import qualified Data.List          as L
 import qualified Data.Maybe         as DM
 import           System.IO          (hPutStrLn, stderr)
+import qualified Data.Either        as E
 
 -- | A datatype representing command line options for the summarise command
 data SummariseOptions = SummariseOptions
@@ -23,7 +24,10 @@ runSummarise (SummariseOptions baseDirs) = do
     let jannoFilePaths = map posPacJannoFile packages
     let jannoFiles = loadJannoFiles jannoFilePaths
     jannoSamples <- fmap concat jannoFiles
-    summarisePoseidonSamples jannoSamples
+    -- show all parsing errors
+    print (E.lefts jannoSamples)
+    -- show actual summary
+    summarisePoseidonSamples (E.rights jannoSamples)
 
 -- | A function to print meaningful summary information for a list of poseidon samples
 summarisePoseidonSamples :: [PoseidonSample] -> IO ()

--- a/src/Poseidon/CmdSummarise.hs
+++ b/src/Poseidon/CmdSummarise.hs
@@ -6,9 +6,9 @@ import           Poseidon.Package   (loadPoseidonPackages,
                                     loadJannoFiles,
                                     PoseidonPackage(..), 
                                     PoseidonSample(..))
-import           Poseidon.Utils     (printPoseidonJannoException)
+import           Poseidon.Utils     (printPoseidonJannoException,
+                                    removeNothing)
 import qualified Data.List          as L
-import qualified Data.Maybe         as DM
 import           System.IO          (hPutStrLn, stderr)
 import qualified Data.Either        as E
 
@@ -78,12 +78,6 @@ pasteFirstN :: Int -> [String] -> String
 pasteFirstN _ [] = "no values"
 pasteFirstN n xs = 
     (L.intercalate ", " $ take n xs) ++ if (length xs > n) then ", ..." else ""
-
--- | A helper function to remove all nothings from a list of maybes
-removeNothing :: [Maybe a] -> [a]
-removeNothing xs =
-    let onlyJust = filter DM.isJust xs
-    in DM.catMaybes onlyJust
 
 -- | A helper function to calculate the mean of a list of doubles
 avg :: [Double] -> Double

--- a/src/Poseidon/CmdSummarise.hs
+++ b/src/Poseidon/CmdSummarise.hs
@@ -26,7 +26,7 @@ runSummarise (SummariseOptions baseDirs) = do
     let jannoFiles = loadJannoFiles jannoFilePaths
     jannoSamples <- fmap concat jannoFiles
     -- show all parsing errors
-    mapM_ (\x -> printPoseidonJannoException x) (E.lefts jannoSamples)
+    mapM_ printPoseidonJannoException (E.lefts jannoSamples)
     -- show actual summary
     summarisePoseidonSamples (E.rights jannoSamples)
 
@@ -35,13 +35,13 @@ summarisePoseidonSamples :: [PoseidonSample] -> IO ()
 summarisePoseidonSamples xs = do
     putStrLn "---"
     putStrLn $ "Number of samples:\t" ++ 
-                (show $ length xs)
+                show (length xs)
     putStrLn $ "Individuals:\t\t" ++ 
                 pasteFirstN 5 (map posSamIndividualID xs)
     putStrLn $ "Sex distribution:\t" ++ 
                 printFrequency ", " (frequency (map posSamGeneticSex xs))
     putStrLn $ "Populations:\t\t" ++ 
-                pasteFirstN 2 (L.nub $ map head (map posSamGroupName xs))
+                pasteFirstN 2 (L.nub $ map (head . posSamGroupName) xs)
     putStrLn $ "Publications:\t\t" ++ 
                 pasteFirstN 2 (L.nub $ removeNothing $ map posSamPublication xs)
     putStrLn $ "Countries:\t\t" ++ 
@@ -88,11 +88,11 @@ removeNothing xs =
 -- | A helper function to calculate the mean of a list of doubles
 avg :: [Double] -> Double
 avg xs = let sum = L.foldl' (+) 0 xs
-         in sum / (fromIntegral $ length xs)
+         in sum / fromIntegral (length xs)
 
 -- | A helper function to round doubles
 roundTo :: Int -> Double -> Double
-roundTo n x = (fromIntegral (floor (x * t))) / t
+roundTo n x = fromIntegral (floor (x * t)) / t
     where t = 10^n
 
 -- | A helper function to calculate the standard deviation of a list of doubles
@@ -116,14 +116,14 @@ frequency list = map (\l -> (head l, length l)) (L.group (L.sort list))
 -- | A helper function to print the output of frequency nicely
 printFrequency :: Show a => String -> [(a,Int)] -> String
 printFrequency _ [] = ""
-printFrequency _ (x:[]) = show (fst x) ++ ": " ++ show (snd x)
+printFrequency _ [x] = show (fst x) ++ ": " ++ show (snd x)
 printFrequency sep (x:xs) = show (fst x) ++ ": " ++ show (snd x) ++ sep ++ printFrequency sep xs
 
 -- | A helper function to print the output of frequency over Maybe values nicely
 printFrequencyMaybe :: Show a => String -> [(Maybe a,Int)] -> String
 printFrequencyMaybe _ [] = ""
-printFrequencyMaybe _ (x:[]) = (maybeShow (fst x)) ++ ": " ++ show (snd x)
-printFrequencyMaybe sep (x:xs) = (maybeShow (fst x)) ++ ": " ++ show (snd x) ++ sep ++ printFrequencyMaybe sep xs
+printFrequencyMaybe _ [x] = maybeShow (fst x) ++ ": " ++ show (snd x)
+printFrequencyMaybe sep (x:xs) = maybeShow (fst x) ++ ": " ++ show (snd x) ++ sep ++ printFrequencyMaybe sep xs
 
 -- | A helper function to unwrap a maybe
 maybeShow :: Show a => Maybe a -> String

--- a/src/Poseidon/CmdSummarise.hs
+++ b/src/Poseidon/CmdSummarise.hs
@@ -6,6 +6,7 @@ import           Poseidon.Package   (loadPoseidonPackages,
                                     loadJannoFiles,
                                     PoseidonPackage(..), 
                                     PoseidonSample(..))
+import           Poseidon.Utils     (printPoseidonJannoException)
 import qualified Data.List          as L
 import qualified Data.Maybe         as DM
 import           System.IO          (hPutStrLn, stderr)
@@ -25,7 +26,7 @@ runSummarise (SummariseOptions baseDirs) = do
     let jannoFiles = loadJannoFiles jannoFilePaths
     jannoSamples <- fmap concat jannoFiles
     -- show all parsing errors
-    mapM_ (\x -> putStrLn $ show x) (E.lefts jannoSamples)
+    mapM_ (\x -> printPoseidonJannoException x) (E.lefts jannoSamples)
     -- show actual summary
     summarisePoseidonSamples (E.rights jannoSamples)
 

--- a/src/Poseidon/CmdSummarise.hs
+++ b/src/Poseidon/CmdSummarise.hs
@@ -23,8 +23,7 @@ runSummarise (SummariseOptions baseDirs) = do
     packages <- loadPoseidonPackages baseDirs
     hPutStrLn stderr $ (show . length $ packages) ++ " Poseidon packages found"
     let jannoFilePaths = map posPacJannoFile packages
-    let jannoFiles = loadJannoFiles jannoFilePaths
-    jannoSamples <- fmap concat jannoFiles
+    jannoSamples <- fmap concat . loadJannoFiles $ jannoFilePaths
     -- show all parsing errors
     mapM_ printPoseidonJannoException (E.lefts jannoSamples)
     -- show actual summary

--- a/src/Poseidon/CmdValidate.hs
+++ b/src/Poseidon/CmdValidate.hs
@@ -19,8 +19,19 @@ runValidate :: ValidateOptions -> IO ()
 runValidate (ValidateOptions baseDirs) = do
     packages <- loadPoseidonPackages baseDirs
     hPutStrLn stderr $ (show . length $ packages) ++ " Poseidon packages found"
+    -- POSEIDON.yml consistency
+    -- ...
+    -- Janno file consistency
     let jannoFilePaths = map posPacJannoFile packages
     let jannoFiles = loadJannoFiles jannoFilePaths
     jannoSamples <- fmap concat jannoFiles
-    -- show all parsing errors
     mapM_ printPoseidonJannoException (E.lefts jannoSamples)
+    -- Genotype file consistency (if available and without loading them completely!)
+    -- ...
+    -- Bibtex file consistency
+    -- ...
+    -- Cross-file consistency
+    -- ...
+    -- Final report: Error code generation
+    -- ...
+

--- a/src/Poseidon/CmdValidate.hs
+++ b/src/Poseidon/CmdValidate.hs
@@ -17,15 +17,18 @@ data ValidateOptions = ValidateOptions
 -- | The main function running the janno command
 runValidate :: ValidateOptions -> IO ()
 runValidate (ValidateOptions baseDirs) = do
+    --
+    putStrLn "POSEIDON.yml consistency:"
     packages <- loadPoseidonPackages baseDirs
-    hPutStrLn stderr $ (show . length $ packages) ++ " Poseidon packages found"
-    -- POSEIDON.yml consistency
-    -- ...
-    -- Janno file consistency
+    hPutStrLn stderr $ (show . length $ packages) ++ " Poseidon packages seem to be fine"
+    --
+    putStrLn "POSEIDON.yml consistency:"
     let jannoFilePaths = map posPacJannoFile packages
     let jannoFiles = loadJannoFiles jannoFilePaths
     jannoSamples <- fmap concat jannoFiles
     mapM_ printPoseidonJannoException (E.lefts jannoSamples)
+    hPutStrLn stderr $ (show . length $ E.rights jannoSamples) ++ " samples seem to be fine"
+    --
     -- Genotype file consistency (if available and without loading them completely!)
     -- ...
     -- Bibtex file consistency

--- a/src/Poseidon/CmdValidate.hs
+++ b/src/Poseidon/CmdValidate.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Poseidon.CmdValidate (runValidate, ValidateOptions(..)) where
+
+import           Poseidon.Package   (loadPoseidonPackages,
+                                    loadJannoFiles,
+                                    PoseidonPackage(..))
+import           Poseidon.Utils     (printPoseidonJannoException)
+import           System.IO          (hPutStrLn, stderr)
+import qualified Data.Either        as E
+
+-- | A datatype representing command line options for the validate command
+data ValidateOptions = ValidateOptions
+    { _jaBaseDirs  :: [FilePath]
+    }
+
+-- | The main function running the janno command
+runValidate :: ValidateOptions -> IO ()
+runValidate (ValidateOptions baseDirs) = do
+    packages <- loadPoseidonPackages baseDirs
+    hPutStrLn stderr $ (show . length $ packages) ++ " Poseidon packages found"
+    let jannoFilePaths = map posPacJannoFile packages
+    let jannoFiles = loadJannoFiles jannoFilePaths
+    jannoSamples <- fmap concat jannoFiles
+    -- show all parsing errors
+    mapM_ printPoseidonJannoException (E.lefts jannoSamples)

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -464,7 +464,7 @@ compFunc2 _                                     []                              
 
 -- | A utility function to load multiple janno files
 loadJannoFiles :: [FilePath] -> IO [[Either PoseidonException PoseidonSample]]
-loadJannoFiles jannoPaths = mapM loadJannoFile jannoPaths
+loadJannoFiles = mapM loadJannoFile
 
 -- | A function to load one janno file
 loadJannoFile :: FilePath -> IO [Either PoseidonException PoseidonSample]
@@ -473,7 +473,7 @@ loadJannoFile jannoPath = do
     let jannoFileUpdated = replaceNA jannoFile
     let jannoFileRows = Bch.lines jannoFileUpdated
     -- tupel with row number and row bytestring
-    let jannoFileRowsWithNumber = zip [1..(length $ jannoFileRows)] jannoFileRows
+    let jannoFileRowsWithNumber = zip [1..(length jannoFileRows)] jannoFileRows
     mapM (loadJannoFileRow jannoPath) (tail jannoFileRowsWithNumber)
 
 -- | A function to load one row of a janno file    
@@ -494,9 +494,9 @@ decodingOptions = Csv.defaultDecodeOptions {
 replaceNA :: Bch.ByteString -> Bch.ByteString
 replaceNA tsv =
    let tsvRows = Bch.lines tsv
-       tsvCells = map (\x -> Bch.splitWith (=='\t') x) tsvRows
+       tsvCells = map (Bch.splitWith (=='\t')) tsvRows
        tsvCellsUpdated = map (\x -> map (\y -> if y == (Bch.pack "n/a") then Bch.empty else y) x) tsvCells
-       tsvRowsUpdated = map (\x -> Bch.intercalate (Bch.pack "\t") x) tsvCellsUpdated
+       tsvRowsUpdated = map (Bch.intercalate (Bch.pack "\t")) tsvCellsUpdated
    in Bch.unlines tsvRowsUpdated
 
 

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -53,6 +53,8 @@ import           System.IO                  (hPutStrLn, stderr)
 import           GHC.Generics               (Generic)
 import qualified Data.Csv                   as Csv
 import           Data.Char                  (ord)
+import qualified Text.CSL.Input.Bibtex      as Bib
+import           Text.CSL.Reference         (Reference(..))
 
 -- | A data type to represent a Poseidon Package
 data PoseidonPackage = PoseidonPackage
@@ -498,5 +500,23 @@ replaceNA tsv =
        tsvCellsUpdated = map (\x -> map (\y -> if y == (Bch.pack "n/a") then Bch.empty else y) x) tsvCells
        tsvRowsUpdated = map (Bch.intercalate (Bch.pack "\t")) tsvCellsUpdated
    in Bch.unlines tsvRowsUpdated
+
+-- BibTeX file parsing
+
+loadBibTeXFiles :: [FilePath] -> IO [Either PoseidonException [Reference]]
+loadBibTeXFiles bibPaths = do
+    mapM loadBibTeXFile bibPaths
+
+loadBibTeXFile :: FilePath -> IO (Either PoseidonException [Reference])
+loadBibTeXFile bibPath = do
+     try (Bib.readBibtex (const True) True False bibPath)
+
+     
+    --  of
+    --     Left err -> do
+    --         return (PoseidonBibTeXException bibPath err)
+    --     Right (bibEntries :: [Reference]) -> do
+    --         return bibEntries
+     
 
 

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -481,11 +481,17 @@ loadJannoFile jannoPath = do
     jannoFile <- Bch.readFile jannoPath
     -- replace n/a with empty
     let jannoFileUpdated = replaceNA jannoFile
-    case Csv.decodeWith decodingOptions Csv.HasHeader jannoFileUpdated of
+    let jannoFileRows = Bch.lines jannoFileUpdated
+    mapM loadJannoFileRow (tail jannoFileRows)
+    
+loadJannoFileRow :: Bch.ByteString -> IO PoseidonSample
+loadJannoFileRow row = do
+    case Csv.decodeWith decodingOptions Csv.NoHeader row of
         Left err -> do
            throwIO $ PoseidonJannoException err
         Right (poseidonSamples :: V.Vector PoseidonSample) -> do
-            return $ V.toList poseidonSamples
+            return $ V.head poseidonSamples
+
 
 -- Janno file loading helper functions and definitions
 

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -16,6 +16,7 @@ module Poseidon.Package (
     getIndividuals,
     loadPoseidonPackages,
     loadJannoFiles,
+    loadBibTeXFiles,
     getJointGenotypeData,
     EigenstratIndEntry(..)
 ) where
@@ -511,12 +512,6 @@ loadBibTeXFile :: FilePath -> IO (Either PoseidonException [Reference])
 loadBibTeXFile bibPath = do
      try (Bib.readBibtex (const True) True False bibPath)
 
-     
-    --  of
-    --     Left err -> do
-    --         return (PoseidonBibTeXException bibPath err)
-    --     Right (bibEntries :: [Reference]) -> do
-    --         return bibEntries
      
 
 

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -332,7 +332,7 @@ findPoseidonPackages baseDir = do
     posPac  <- mapM tryReadPoseidonPackage . map (baseDir </>) . filter ((=="POSEIDON.yml") . takeFileName) $ entries
     forM_ (lefts posPac) $ (\e -> case e of
         PoseidonYamlParseException fp err ->
-            putStrLn ("Skipping package at " ++ fp ++ " due to YAML parsing error: " ++ show err)
+            putStrLn ("Can't read package at " ++ fp ++ " due to YAML parsing error: " ++ show err)
         _ -> error "this should never happen")
     subDirs     <- filterM doesDirectoryExist . map (baseDir </>) $ entries
     morePosPacs <- fmap concat . mapM findPoseidonPackages $ subDirs

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -472,16 +472,18 @@ loadJannoFile jannoPath = do
     jannoFile <- Bch.readFile jannoPath
     let jannoFileUpdated = replaceNA jannoFile
     let jannoFileRows = Bch.lines jannoFileUpdated
-    mapM loadJannoFileRow (tail jannoFileRows)
-    
-loadJannoFileRow :: Bch.ByteString -> IO (Either PoseidonException PoseidonSample)
-loadJannoFileRow row = do
-    case Csv.decodeWith decodingOptions Csv.NoHeader row of
+    -- tupel with row number and row bytestring
+    let jannoFileRowsWithNumber = zip [1..(length $ jannoFileRows)] jannoFileRows
+    mapM (loadJannoFileRow jannoPath) (tail jannoFileRowsWithNumber)
+
+-- | A function to load one row of a janno file    
+loadJannoFileRow :: FilePath -> (Int, Bch.ByteString) -> IO (Either PoseidonException PoseidonSample)
+loadJannoFileRow jannoPath row = do
+    case Csv.decodeWith decodingOptions Csv.NoHeader (snd row) of
         Left err -> do
-           return $ Left (PoseidonJannoException err)
+           return $ Left (PoseidonJannoException jannoPath (fst row) err)
         Right (poseidonSamples :: V.Vector PoseidonSample) -> do
            return $ Right $ V.head poseidonSamples
-
 
 decodingOptions :: Csv.DecodeOptions
 decodingOptions = Csv.defaultDecodeOptions { 

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -8,7 +8,7 @@ data PoseidonException = PoseidonYamlParseException FilePath ParseException -- ^
     | PoseidonPackageException String -- ^ An exception to represent a logical error in a package
     | PoseidonIndSearchException String -- ^ An exception to represent an error when searching for individuals or populations
     | PoseidonGenotypeException String -- ^ An exception to represent errors when trying to parse the genotype data
-    | PoseidonJannoException String -- ^ An exception to represent errors when trying to parse the .janno file
+    | PoseidonJannoException FilePath Int String-- ^ An exception to represent errors when trying to parse the .janno file
     | PoseidonFStatsFormatException String -- ^ An exception type to represent FStat specification errors
     deriving (Show)
 

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -17,6 +17,7 @@ instance Exception PoseidonException
 
 printPoseidonJannoException :: PoseidonException -> IO()
 printPoseidonJannoException (PoseidonJannoException f i s) = 
-    putStrLn $  "Parsing error in " ++ f 
-                ++ " in line " ++ (show i) 
-                -- ++ ": " ++ s
+    putStrLn $  "Can't read sample in " ++ f 
+                ++ " in line " ++ (show i)
+                ++ " due to .janno parsing error: "
+                ++ s

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -11,6 +11,7 @@ data PoseidonException =
     | PoseidonGenotypeException String -- ^ An exception to represent errors when trying to parse the genotype data
     | PoseidonJannoException FilePath Int String-- ^ An exception to represent errors when trying to parse the .janno file
     | PoseidonFStatsFormatException String -- ^ An exception type to represent FStat specification errors
+    | PoseidonBibTeXException FilePath String -- ^ An exception to represent errors when trying to parse the .bib file
     deriving (Show)
 
 instance Exception PoseidonException

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -1,7 +1,12 @@
-module Poseidon.Utils (PoseidonException(..), printPoseidonJannoException) where
+module Poseidon.Utils (
+    PoseidonException(..), 
+    printPoseidonJannoException,
+    removeNothing
+) where
 
 import           Control.Exception          (Exception)
 import           Data.Yaml                  (ParseException)
+import qualified Data.Maybe                 as DM
 
 -- | A Poseidon Exception data type with several concrete constructors
 data PoseidonException = 
@@ -22,3 +27,9 @@ printPoseidonJannoException (PoseidonJannoException f i s) =
                 ++ " in line " ++ (show i)
                 ++ " due to .janno parsing error: "
                 ++ s
+
+-- | A helper function to remove all nothings from a list of maybes
+removeNothing :: [Maybe a] -> [a]
+removeNothing xs =
+    let onlyJust = filter DM.isJust xs
+    in DM.catMaybes onlyJust

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -1,10 +1,11 @@
-module Poseidon.Utils (PoseidonException(..)) where
+module Poseidon.Utils (PoseidonException(..), printPoseidonJannoException) where
 
 import           Control.Exception          (Exception)
 import           Data.Yaml                  (ParseException)
 
 -- | A Poseidon Exception data type with several concrete constructors
-data PoseidonException = PoseidonYamlParseException FilePath ParseException -- ^ An exception to represent YAML parsing errors
+data PoseidonException = 
+    PoseidonYamlParseException FilePath ParseException -- ^ An exception to represent YAML parsing errors
     | PoseidonPackageException String -- ^ An exception to represent a logical error in a package
     | PoseidonIndSearchException String -- ^ An exception to represent an error when searching for individuals or populations
     | PoseidonGenotypeException String -- ^ An exception to represent errors when trying to parse the genotype data
@@ -13,3 +14,9 @@ data PoseidonException = PoseidonYamlParseException FilePath ParseException -- ^
     deriving (Show)
 
 instance Exception PoseidonException
+
+printPoseidonJannoException :: PoseidonException -> IO()
+printPoseidonJannoException (PoseidonJannoException f i s) = 
+    putStrLn $  "Parsing error in " ++ f 
+                ++ " in line " ++ (show i) 
+                -- ++ ": " ++ s


### PR DESCRIPTION
I finally figured out a way this error management could be done. I wish the within-row error messages could be more useful. Like this they're not even worth printing.