### PR TITLE
implemented intersect option for forge.

### DIFF
--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -148,6 +148,7 @@ forgeOptParser :: OP.Parser ForgeOptions
 forgeOptParser = ForgeOptions <$> parseBasePaths
                               <*> parseForgeEntitiesDirect
                               <*> parseForgeEntitiesFromFile
+                              <*> parseIntersect
                               <*> parseOutPackagePath
                               <*> parseOutPackageName
                               <*> parseShowWarnings
@@ -229,6 +230,13 @@ parseForgeEntitiesFromFile = OP.option (Just <$> OP.str) (OP.long "forgeFile" <>
     OP.help "A file with a list of packages, groups or individual samples. \
     \Works just as -f, but multiple values can also be separated by newline, not just by comma. \
     \-f and --forgeFile can be combined.")
+
+parseIntersect :: OP.Parser (Bool)
+parseIntersect = OP.switch (OP.long "intersect" <>
+    OP.help "Whether to output the intersection of the genotype files to be forged. \
+        \The default (if this option is not set) is to output the union of all SNPs, with genotypes \
+        \defined as missing in those packages which do not have a SNP that is present in another package. \
+        \With this option set, the forged dataset will typically have fewer SNPs, but less missingness.")
 
 parseFetchEntitiesFromFile :: OP.Parser (Maybe FilePath)
 parseFetchEntitiesFromFile = OP.option (Just <$> OP.str) (OP.long "fetchFile" <>

--- a/src/Poseidon/CLI/FStats.hs
+++ b/src/Poseidon/CLI/FStats.hs
@@ -232,7 +232,7 @@ runFstats (FstatsOptions baseDirs jackknifeMode exclusionList statSpecsDirect ma
         forM_ relevantPackages $ \pac -> hPutStrLn stderr (posPacTitle pac)
         hPutStrLn stderr $ "Computing stats " ++ show statSpecs
         blockData <- runSafeT $ do
-            (eigenstratIndEntries, eigenstratProd) <- getJointGenotypeData False relevantPackages
+            (eigenstratIndEntries, eigenstratProd) <- getJointGenotypeData False False relevantPackages
             let eigenstratProdFiltered = eigenstratProd >-> P.filter chromFilter
                 eigenstratProdInChunks = case jackknifeMode of
                     JackknifePerChromosome  -> chunkEigenstratByChromosome eigenstratProdFiltered

--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -36,6 +36,7 @@ data ForgeOptions = ForgeOptions
     { _jaBaseDirs :: [FilePath]
     , _entityList :: EntitiesList
     , _entityFile :: Maybe FilePath
+    , _intersect :: Bool
     , _outPacPath :: FilePath
     , _outPacName :: String
     , _showWarnings :: Bool
@@ -43,7 +44,7 @@ data ForgeOptions = ForgeOptions
 
 -- | The main function running the forge command
 runForge :: ForgeOptions -> IO ()
-runForge (ForgeOptions baseDirs entitiesDirect entitiesFile outPath outName showWarnings) = do
+runForge (ForgeOptions baseDirs entitiesDirect entitiesFile intersect outPath outName showWarnings) = do
     -- compile entities
     entitiesFromFile <- case entitiesFile of
         Nothing -> return []
@@ -96,7 +97,7 @@ runForge (ForgeOptions baseDirs entitiesDirect entitiesFile outPath outName show
     -- genotype data
     hPutStrLn stderr "Compiling genotype data"
     runSafeT $ do
-        (eigenstratIndEntries, eigenstratProd) <- getJointGenotypeData showWarnings relevantPackages
+        (eigenstratIndEntries, eigenstratProd) <- getJointGenotypeData showWarnings intersect relevantPackages
         let eigenstratIndEntriesV = V.fromList eigenstratIndEntries
         let newEigenstratIndEntries = [eigenstratIndEntriesV V.! i | i <- indices]
         let jannoIndIds = map posSamIndividualID relevantJannoRows

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -431,11 +431,12 @@ getIndividuals pac = loadIndividuals (posPacBaseDir pac) (posPacGenotypeData pac
 
 -- | A function to read genotype data jointly from multiple packages
 getJointGenotypeData :: (MonadSafe m) => Bool -- ^ whether to show all warnings
+                     -> Bool -- ^ whether to generate an intersection instead of union of input sites
                      -> [PoseidonPackage] -- ^ A list of poseidon packages.
                      -> m ([EigenstratIndEntry], Producer (EigenstratSnpEntry, GenoLine) m ())
                      -- ^ a pair of the EigenstratIndEntries and a Producer over the Snp position values and the genotype line, joined across all packages.
-getJointGenotypeData showAllWarnings pacs =
-    loadJointGenotypeData showAllWarnings [(posPacBaseDir pac, posPacGenotypeData pac) | pac <- pacs]
+getJointGenotypeData showAllWarnings intersect pacs =
+    loadJointGenotypeData showAllWarnings intersect [(posPacBaseDir pac, posPacGenotypeData pac) | pac <- pacs]
 
 -- | A function to create a dummy POSEIDON.yml file
 -- This will take only the filenames of the provided files, so it assumes that the files will be copied into 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,3 +18,4 @@ extra-deps:
 - hslua-module-text-0.2.1
 - skylighting-0.8.5
 - skylighting-core-0.8.5
+- pipes-ordered-zip-1.2.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -109,6 +109,13 @@ packages:
       sha256: 0bae843648475c76fc412153a40b62be0072a6251b6486d2108c2234ddc56f60
   original:
     hackage: skylighting-core-0.8.5
+- completed:
+    hackage: pipes-ordered-zip-1.2.1@sha256:1bece0cde4315987da28b6a588dd3345dda8f61bb6894e4e4c9c3cd3a4646746,1453
+    pantry-tree:
+      size: 446
+      sha256: 099f71b0cecdaee9feae0bbf165491c57082ee259f7b5a593f96cfbccd36ba49
+  original:
+    hackage: pipes-ordered-zip-1.2.1
 snapshots:
 - completed:
     size: 563098


### PR DESCRIPTION
New option `--intersect` for forge now allows to output only those SNPs that are common in all to-be-forged packages.

compiles and the output looks correct in terms of number of sites, but before merging we better make one actual test by a user.