### PR TITLE
Enable the list module to list from remote

### DIFF
--- a/src/Poseidon/CLI/List.hs
+++ b/src/Poseidon/CLI/List.hs
@@ -15,12 +15,12 @@ import           Text.Layout.Table          (asciiRoundS, column, def, expand,
 
 -- | A datatype representing command line options for the list command
 data ListOptions = ListOptions
-    { _loBaseDirs    :: [FilePath] -- ^ the list of base directories to search for packages
-    -- ^ what to list
-    , _loListEntity  :: ListEntity -- ^ what to list
-    -- ^ whether to output raw TSV instead of a nicely formatted table
-    , _loRawOutput   :: Bool -- ^ whether to output raw TSV instead of a nicely formatted table
-    , _optIgnoreGeno :: Bool
+    { _loBaseDirs     :: Maybe [FilePath] -- ^ the list of base directories to search for packages
+    , _loRemote       :: Bool -- ^ list data froma a remote server
+    , _loRemoteURL    :: String -- ^ remote server URL
+    , _loListEntity   :: ListEntity -- ^ what to list
+    , _loRawOutput    :: Bool -- ^ whether to output raw TSV instead of a nicely formatted table
+    , _optIgnoreGeno  :: Bool
     }
 
 -- | A datatype to represent the options what to list
@@ -30,7 +30,9 @@ data ListEntity = ListPackages
 
 -- | The main function running the list command
 runList :: ListOptions -> IO ()
-runList (ListOptions baseDirs listEntity rawOutput ignoreGeno) = do
+runList (ListOptions _ True remoteURL listEntity rawOutput _) = do
+    putStrLn "Stri"
+runList (ListOptions (Just baseDirs) False _ listEntity rawOutput ignoreGeno) = do
     allPackages <- readPoseidonPackageCollection True ignoreGeno baseDirs
     (tableH, tableB) <- case listEntity of
         ListPackages -> do

--- a/src/Poseidon/CLI/List.hs
+++ b/src/Poseidon/CLI/List.hs
@@ -78,17 +78,19 @@ runList (ListOptions _ True remoteURL listEntity rawOutput _) = do
                         groupNrInds = show (length oneGroup)
                     return [groupName, groupPacs, groupNrInds]
             return (tableH, tableB)
+        ListIndividuals -> do
+            let tableH = ["Package", "Individual", "Group"]
+            let tableB = do
+                    oneSample <- allRemoteSamples
+                    return [remSamPacTitle oneSample, remSamIndividualID oneSample, remSamGroupName oneSample]
+            hPutStrLn stderr ("found " ++ show (length tableB) ++ " individuals.")
+            return (tableH, tableB)
 
     if rawOutput then
         putStrLn $ intercalate "\n" [intercalate "\t" row | row <- tableB]
-    else 
-        case listEntity of
-            ListGroups -> do
-                let colSpecs = replicate 3 (column (expandUntil 50) def def def)
-                putStrLn $ tableString colSpecs asciiRoundS (titlesH tableH) [rowsG tableB]
-            _ -> do
-                let colSpecs = replicate 3 (column expand def def def)
-                putStrLn $ tableString colSpecs asciiRoundS (titlesH tableH) [rowsG tableB]
+    else do
+        let colSpecs = replicate 3 (column (expandUntil 60) def def def)
+        putStrLn $ tableString colSpecs asciiRoundS (titlesH tableH) [rowsG tableB]
 
 runList (ListOptions (Just baseDirs) False _ listEntity rawOutput ignoreGeno) = do
     -- load local packages
@@ -109,32 +111,27 @@ runList (ListOptions (Just baseDirs) False _ listEntity rawOutput ignoreGeno) = 
                     jannoRow <- posPacJanno pac
                     return [posPacTitle pac, posSamIndividualID jannoRow, head (posSamGroupName jannoRow)]
             let allIndsSortedByGroup = groupBy (\a b -> a!!2 == b!!2) . sortOn (!!2) $ allInds
+            let tableH = ["Group", "Packages", "Nr Individuals"]
                 tableB = do
                     indGroup <- allIndsSortedByGroup
                     let packages_ = nub [i!!0 | i <- indGroup]
                     let nrInds = length indGroup
                     return [(indGroup!!0)!!2, intercalate "," packages_, show nrInds]
-            let tableH = ["Group", "Packages", "Nr Individuals"]
             return (tableH, tableB)
         ListIndividuals -> do
+            let tableH = ["Package", "Individual", "Group"]
             let tableB = do
                     pac <- allPackages
                     jannoRow <- posPacJanno pac
                     return [posPacTitle pac, posSamIndividualID jannoRow, head (posSamGroupName jannoRow)]
             hPutStrLn stderr ("found " ++ show (length tableB) ++ " individuals.")
-            let tableH = ["Package", "Individual", "Population"]
             return (tableH, tableB)
 
     if rawOutput then
         putStrLn $ intercalate "\n" [intercalate "\t" row | row <- tableB]
-    else
-        case listEntity of
-            ListGroups -> do
-                let colSpecs = replicate 3 (column (expandUntil 50) def def def)
-                putStrLn $ tableString colSpecs asciiRoundS (titlesH tableH) [rowsG tableB]
-            _ -> do
-                let colSpecs = replicate 3 (column expand def def def)
-                putStrLn $ tableString colSpecs asciiRoundS (titlesH tableH) [rowsG tableB]
+    else do
+        let colSpecs = replicate 3 (column (expandUntil 60) def def def)
+        putStrLn $ tableString colSpecs asciiRoundS (titlesH tableH) [rowsG tableB]
   where
     showMaybeDate (Just d) = show d
     showMaybeDate Nothing  = "n/a"


### PR DESCRIPTION
If merged this closes #50. 

If you want to list local entities you run  

```
trident list -d . --individuals/--packages/--groups
```

So nothing changed here. For remote entities you replace `-d` with `--remote`:

```
trident list --remote --individuals/--packages/--groups
```

If both `-d` and `--remote` are provided, then -d is silently ignored. 

```
trident list -d . --remote --individuals/--packages/--groups
```
The remote's URL can be modified with `--remoteURL`.
