### PR TITLE
Extend list command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - name: Setup Haskell
       uses: haskell/actions/setup@v1

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -198,14 +198,8 @@ makeZipArchive pac ignoreGenoFiles =
         let zipEntry = toEntry fn modTime raw
         return (addEntryToArchive zipEntry a)
 
-getAllIndividualInfo :: [PoseidonPackage] -> [IndividualInfo]
-getAllIndividualInfo packages = do
-    pac <- packages
-    jannoRow <- posPacJanno pac
-    let name = posSamIndividualID jannoRow
-        group = head . posSamGroupName $ jannoRow
-        pacName = posPacTitle pac
-    return $ IndividualInfo name group pacName
+getAllIndividualInfo :: [PoseidonPackage] -> [(String, Janno)]
+getAllIndividualInfo packages = [(posPacTitle pac, posPacJanno pac) |pac <- packages]
 
 optParserInfo :: OP.ParserInfo CommandLineOptions
 optParserInfo = OP.info (OP.helper <*> versionOption <*> optParser) (

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import           Poseidon.GenotypeData       (GenotypeDataSpec (..))
-import           Poseidon.Janno              (PoseidonSample (..))
+import           Poseidon.Janno              (JannoRow (..))
 import           Poseidon.Package            (PackageInfo (..),
                                               PoseidonPackage (..),
                                               readPoseidonPackageCollection)
-import           Poseidon.Utils              (IndividualInfo (..))
 
 import           Codec.Archive.Zip           (Archive, addEntryToArchive,
                                               emptyArchive, fromArchive,
@@ -94,7 +93,7 @@ main = do
                 Just fn -> file fn
                 Nothing -> raise ("unknown package " <> p)
         get "/individuals_all" $
-            json (getAllIndividualInfo allPackages)
+            json (getAllPacJannoPairs allPackages)
         notFound $ raise "Unknown request"
   where
     p = OP.prefs OP.showHelpOnEmpty
@@ -198,8 +197,8 @@ makeZipArchive pac ignoreGenoFiles =
         let zipEntry = toEntry fn modTime raw
         return (addEntryToArchive zipEntry a)
 
-getAllIndividualInfo :: [PoseidonPackage] -> [(String, Janno)]
-getAllIndividualInfo packages = [(posPacTitle pac, posPacJanno pac) |pac <- packages]
+getAllPacJannoPairs :: [PoseidonPackage] -> [(String, [JannoRow])]
+getAllPacJannoPairs packages = [(posPacTitle pac, posPacJanno pac) | pac <- packages]
 
 optParserInfo :: OP.ParserInfo CommandLineOptions
 optParserInfo = OP.info (OP.helper <*> versionOption <*> optParser) (

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -5,6 +5,7 @@ import           Poseidon.Janno              (JannoRow (..))
 import           Poseidon.Package            (PackageInfo (..),
                                               PoseidonPackage (..),
                                               readPoseidonPackageCollection)
+import           Poseidon.Utils              (IndividualInfo (..))
 
 import           Codec.Archive.Zip           (Archive, addEntryToArchive,
                                               emptyArchive, fromArchive,
@@ -92,8 +93,10 @@ main = do
             case zipFN of
                 Just fn -> file fn
                 Nothing -> raise ("unknown package " <> p)
-        get "/individuals_all" $
+        get "/janno_all" $
             json (getAllPacJannoPairs allPackages)
+        get "/individuals_all" $
+            json (getAllIndividualInfo allPackages)
         notFound $ raise "Unknown request"
   where
     p = OP.prefs OP.showHelpOnEmpty
@@ -196,6 +199,15 @@ makeZipArchive pac ignoreGenoFiles =
         modTime <- (round . utcTimeToPOSIXSeconds) <$> getModificationTime fullFN
         let zipEntry = toEntry fn modTime raw
         return (addEntryToArchive zipEntry a)
+
+getAllIndividualInfo :: [PoseidonPackage] -> [IndividualInfo]
+getAllIndividualInfo packages = do
+    pac <- packages
+    jannoRow <- posPacJanno pac
+    let name = jIndividualID jannoRow
+        group = head . jGroupName $ jannoRow
+        pacName = posPacTitle pac
+    return $ IndividualInfo name group pacName
 
 getAllPacJannoPairs :: [PoseidonPackage] -> [(String, [JannoRow])]
 getAllPacJannoPairs packages = [(posPacTitle pac, posPacJanno pac) | pac <- packages]

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -329,11 +329,15 @@ parseShowWarnings :: OP.Parser Bool
 parseShowWarnings = OP.switch (OP.long "warnings" <> OP.short 'w' <> OP.help "Show all warnings for merging genotype data")
 
 parseListEntity :: OP.Parser ListEntity
-parseListEntity = parseListPackages <|> parseListGroups <|> parseListIndividuals
+parseListEntity = parseListPackages <|> parseListGroups <|> (parseListIndividualsDummy *> parseListIndividualsExtraCols)
   where
     parseListPackages = OP.flag' ListPackages (OP.long "packages" <> OP.help "list all packages")
     parseListGroups = OP.flag' ListGroups (OP.long "groups" <> OP.help "list all groups, ignoring any group names after the first as specified in the Janno-file")
-    parseListIndividuals = OP.flag' ListIndividuals (OP.long "individuals" <> OP.help "list individuals")
+    parseListIndividualsDummy = OP.flag' () (OP.long "individuals" <> OP.help "list individuals")
+    parseListIndividualsExtraCols = ListIndividuals <$> OP.many parseExtraCol
+    parseExtraCol = OP.strOption (OP.short 'j' <> OP.long "jannoColumn" <> OP.metavar "JANNO_HEADER" <>
+        OP.help "list additional fields from the janno files, using the Janno column heading name, such as \
+        \Country, Site, Date_C14_Uncal_BP, Endogenous, ...")
 
 parseRawOutput :: OP.Parser Bool
 parseRawOutput = OP.switch (

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -331,8 +331,8 @@ parseShowWarnings = OP.switch (OP.long "warnings" <> OP.short 'w' <> OP.help "Sh
 parseListEntity :: OP.Parser ListEntity
 parseListEntity = parseListPackages <|> parseListGroups <|> parseListIndividuals
   where
-    parseListPackages = OP.flag' ListPackages (OP.long "packages" <> OP.help "list packages")
-    parseListGroups = OP.flag' ListGroups (OP.long "groups" <> OP.help "list groups")
+    parseListPackages = OP.flag' ListPackages (OP.long "packages" <> OP.help "list all packages")
+    parseListGroups = OP.flag' ListGroups (OP.long "groups" <> OP.help "list all groups, ignoring any group names after the first as specified in the Janno-file")
     parseListIndividuals = OP.flag' ListIndividuals (OP.long "individuals" <> OP.help "list individuals")
 
 parseRawOutput :: OP.Parser Bool

--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -108,7 +108,7 @@ runForge (ForgeOptions baseDirs entitiesDirect entitiesFile intersect outPath ou
         (eigenstratIndEntries, eigenstratProd) <- getJointGenotypeData showWarnings intersect relevantPackages
         let eigenstratIndEntriesV = V.fromList eigenstratIndEntries
         let newEigenstratIndEntries = [eigenstratIndEntriesV V.! i | i <- indices]
-        let jannoIndIds = map posSamIndividualID relevantJannoRows
+        let jannoIndIds = map jIndividualID relevantJannoRows
         -- TODO: This check might be redundant now, because the input data is now already
         -- screened for cross-file order issues
         when ([n | EigenstratIndEntry n _ _ <-  newEigenstratIndEntries] /= jannoIndIds) $
@@ -154,15 +154,15 @@ filterPackages entities packages = do
         then return (Just pac)
         else return Nothing
 
-filterJannoRows :: EntitiesList -> [PoseidonSample] -> [PoseidonSample]
+filterJannoRows :: EntitiesList -> [JannoRow] -> [JannoRow]
 filterJannoRows entities samples =
     let groupNamesStats = [ group | Group group <- entities]
         indNamesStats   = [ ind   | Ind   ind   <- entities]
-        comparison x    =  posSamIndividualID x `elem` indNamesStats
-                           || head (posSamGroupName x) `elem` groupNamesStats
+        comparison x    =  jIndividualID x `elem` indNamesStats
+                           || head (jGroupName x) `elem` groupNamesStats
     in filter comparison samples
 
-filterJannoFiles :: EntitiesList -> [(String, [PoseidonSample])] -> [PoseidonSample]
+filterJannoFiles :: EntitiesList -> [(String, [JannoRow])] -> [JannoRow]
 filterJannoFiles entities packages =
     let requestedPacs           = [ pac | Pac pac <- entities]
         filterJannoOrNot (a, b) = if a `elem` requestedPacs
@@ -170,9 +170,9 @@ filterJannoFiles entities packages =
                                   else filterJannoRows entities b
     in concatMap filterJannoOrNot packages
 
-filterBibEntries :: [PoseidonSample] -> [Reference] -> [Reference]
+filterBibEntries :: [JannoRow] -> [Reference] -> [Reference]
 filterBibEntries samples references =
-    let relevantPublications = nub $ mapMaybe posSamPublication samples
+    let relevantPublications = nub $ mapMaybe jPublication samples
     in filter (\x-> (unpack . unLiteral . refId) x `elem` relevantPublications) references
 
 extractEntityIndices :: EntitiesList -> [PoseidonPackage] -> IO [Int]

--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -7,7 +7,7 @@ import           Poseidon.EntitiesList      (EntitiesList (..),
 import           Poseidon.GenotypeData      (GenotypeDataSpec (..),
                                              GenotypeFormatSpec (..),
                                              printSNPCopyProgress)
-import           Poseidon.Janno             (PoseidonSample (..),
+import           Poseidon.Janno             (JannoRow (..),
                                              writeJannoFile)
 import           Poseidon.Package           (ContributorSpec (..),
                                              PoseidonPackage (..), getChecksum,

--- a/src/Poseidon/CLI/List.hs
+++ b/src/Poseidon/CLI/List.hs
@@ -44,7 +44,7 @@ runList (ListOptions repoLocation listEntity rawOutput ignoreGeno) = do
         RepoRemote remoteURL -> do
             -- load remote samples list
             hPutStrLn stderr "Downloading sample list from remote"
-            remoteOverviewJSONByteString <- simpleHttp (remoteURL ++ "/individuals_all")
+            remoteOverviewJSONByteString <- simpleHttp (remoteURL ++ "/janno_all")
             readSampleInfo remoteOverviewJSONByteString
         RepoLocal baseDirs -> do
             allPackages <- readPoseidonPackageCollection True ignoreGeno baseDirs

--- a/src/Poseidon/CLI/Summarise.hs
+++ b/src/Poseidon/CLI/Summarise.hs
@@ -2,7 +2,7 @@
 
 module Poseidon.CLI.Summarise where
 
-import           Poseidon.Janno         (Percent (..), PoseidonSample (..))
+import           Poseidon.Janno         (Percent (..), JannoRow (..))
 import           Poseidon.MathHelpers   (meanAndSdRoundTo, meanAndSdInteger)
 import           Poseidon.Package       (PoseidonPackage(..), readPoseidonPackageCollection)
 
@@ -24,32 +24,32 @@ runSummarise :: SummariseOptions -> IO ()
 runSummarise (SummariseOptions baseDirs rawOutput) = do
     allPackages <- readPoseidonPackageCollection True True baseDirs
     let jannos = map posPacJanno allPackages
-    summarisePoseidonSamples (concat jannos) rawOutput
+    summariseJannoRows (concat jannos) rawOutput
 
 -- | A function to print meaningful summary information for a list of poseidon samples
-summarisePoseidonSamples :: [PoseidonSample] -> Bool -> IO ()
-summarisePoseidonSamples xs rawOutput = do
+summariseJannoRows :: [JannoRow] -> Bool -> IO ()
+summariseJannoRows xs rawOutput = do
     (tableH, tableB) <- do
         let tableH = ["Summary", "Value"]
             tableB = [
                 ["Nr Individuals", show (length xs)],
-                ["Individuals", paste $ sort $ map posSamIndividualID xs],
-                ["Nr Groups", show $ length $ nub $ map posSamGroupName xs],
-                ["Groups", printFrequencyString ", " $ frequency $ map (head . posSamGroupName) xs],
-                ["Nr Publications", show $ length $ nub $ map posSamPublication xs],
-                ["Publications", printFrequencyMaybeString ", " $ frequency $ map posSamPublication xs],
-                ["Nr Countries", show $ length $ nub $ map posSamCountry xs],
-                ["Countries", printFrequencyMaybeString ", " $ frequency $ map posSamCountry xs],
-                ["Mean age BC/AD", meanAndSdInteger $ map fromIntegral $ mapMaybe posSamDateBCADMedian xs],
-                ["Dating type", printFrequencyMaybe ", " $ frequency $ map posSamDateType xs],
-                ["Sex distribution", printFrequency ", " $ frequency $ map posSamGeneticSex xs],
-                ["MT haplogroups", printFrequencyMaybeString ", " $ frequency $ map posSamMTHaplogroup xs],
-                ["Y haplogroups",printFrequencyMaybeString ", " $ frequency $ map posSamYHaplogroup xs],
-                ["% endogenous human DNA", meanAndSdRoundTo 2 $ map (\(Percent x) -> x) $ mapMaybe posSamEndogenous xs],
-                ["Nr of SNPs on 1240K", meanAndSdInteger $ map fromIntegral $ mapMaybe posSamNrAutosomalSNPs xs],
-                ["Coverage on 1240K", meanAndSdRoundTo 2 $ mapMaybe posSamCoverage1240K xs],
-                ["Library type", printFrequencyMaybe ", " $ frequency $ map posSamLibraryBuilt xs],
-                ["UDG treatment", printFrequencyMaybe ", " $ frequency $ map posSamUDG xs]
+                ["Individuals", paste $ sort $ map jIndividualID xs],
+                ["Nr Groups", show $ length $ nub $ map jGroupName xs],
+                ["Groups", printFrequencyString ", " $ frequency $ map (head . jGroupName) xs],
+                ["Nr Publications", show $ length $ nub $ map jPublication xs],
+                ["Publications", printFrequencyMaybeString ", " $ frequency $ map jPublication xs],
+                ["Nr Countries", show $ length $ nub $ map jCountry xs],
+                ["Countries", printFrequencyMaybeString ", " $ frequency $ map jCountry xs],
+                ["Mean age BC/AD", meanAndSdInteger $ map fromIntegral $ mapMaybe jDateBCADMedian xs],
+                ["Dating type", printFrequencyMaybe ", " $ frequency $ map jDateType xs],
+                ["Sex distribution", printFrequency ", " $ frequency $ map jGeneticSex xs],
+                ["MT haplogroups", printFrequencyMaybeString ", " $ frequency $ map jMTHaplogroup xs],
+                ["Y haplogroups",printFrequencyMaybeString ", " $ frequency $ map jYHaplogroup xs],
+                ["% endogenous human DNA", meanAndSdRoundTo 2 $ map (\(Percent x) -> x) $ mapMaybe jEndogenous xs],
+                ["Nr of SNPs on 1240K", meanAndSdInteger $ map fromIntegral $ mapMaybe jNrAutosomalSNPs xs],
+                ["Coverage on 1240K", meanAndSdRoundTo 2 $ mapMaybe jCoverage1240K xs],
+                ["Library type", printFrequencyMaybe ", " $ frequency $ map jLibraryBuilt xs],
+                ["UDG treatment", printFrequencyMaybe ", " $ frequency $ map jUDG xs]
                 ]
         return (tableH, tableB)
     let colSpecs = replicate 2 (column (expandUntil 60) def def def)

--- a/src/Poseidon/CLI/Survey.hs
+++ b/src/Poseidon/CLI/Survey.hs
@@ -52,7 +52,7 @@ runSurvey (SurveyOptions baseDirs rawOutput) = do
 extractFirst :: (a, b, c, d) -> a
 extractFirst (a,_,_,_) = a
 
-renderPackageWithCompleteness :: (String,Bool,Janno,BibTeX) -> String
+renderPackageWithCompleteness :: (String, Bool, [JannoRow], BibTeX) -> String
 renderPackageWithCompleteness (_,genoTypeDataExists,janno,bib) =
        (if genoTypeDataExists then "G" else ".")
     ++ "-"
@@ -60,46 +60,46 @@ renderPackageWithCompleteness (_,genoTypeDataExists,janno,bib) =
     ++ "-"
     ++ (if not (null bib) then "B" else ".")
 
-renderJannoCompleteness :: Janno -> String
+renderJannoCompleteness :: [JannoRow] -> String
 renderJannoCompleteness jS =
     "M"
-    ++ allNothing posSamCollectionID jS
-    ++ allNothing posSamSourceTissue jS
-    ++ allNothing posSamCountry jS
-    ++ allNothing posSamLocation jS
-    ++ allNothing posSamSite jS
-    ++ allNothing posSamLatitude jS
-    ++ allNothing posSamLongitude jS
-    ++ allNothing posSamDateC14Labnr jS
-    ++ allNothing posSamDateC14UncalBP jS
-    ++ allNothing posSamDateC14UncalBPErr jS
-    ++ allNothing posSamDateBCADMedian jS
-    ++ allNothing posSamDateBCADStart jS
-    ++ allNothing posSamDateBCADStop jS
-    ++ allNothing posSamDateType jS
-    ++ allNothing posSamNrLibraries jS
-    ++ allNothing posSamDataType jS
-    ++ allNothing posSamGenotypePloidy jS
+    ++ allNothing jCollectionID jS
+    ++ allNothing jSourceTissue jS
+    ++ allNothing jCountry jS
+    ++ allNothing jLocation jS
+    ++ allNothing jSite jS
+    ++ allNothing jLatitude jS
+    ++ allNothing jLongitude jS
+    ++ allNothing jDateC14Labnr jS
+    ++ allNothing jDateC14UncalBP jS
+    ++ allNothing jDateC14UncalBPErr jS
+    ++ allNothing jDateBCADMedian jS
+    ++ allNothing jDateBCADStart jS
+    ++ allNothing jDateBCADStop jS
+    ++ allNothing jDateType jS
+    ++ allNothing jNrLibraries jS
+    ++ allNothing jDataType jS
+    ++ allNothing jGenotypePloidy jS
     ++ "M"
     ++ "M"
-    ++ allNothing posSamNrAutosomalSNPs jS
-    ++ allNothing posSamCoverage1240K jS
-    ++ allNothing posSamMTHaplogroup jS
-    ++ allNothing posSamYHaplogroup jS
-    ++ allNothing posSamEndogenous jS
-    ++ allNothing posSamUDG jS
-    ++ allNothing posSamDamage jS
-    ++ allNothing posSamNuclearContam jS
-    ++ allNothing posSamNuclearContamErr jS
-    ++ allNothing posSamMTContam jS
-    ++ allNothing posSamMTContamErr jS
-    ++ allNothing posSamPrimaryContact jS
-    ++ allNothing posSamPublication jS
-    ++ allNothing posSamComments jS
-    ++ allNothing posSamKeywords jS
+    ++ allNothing jNrAutosomalSNPs jS
+    ++ allNothing jCoverage1240K jS
+    ++ allNothing jMTHaplogroup jS
+    ++ allNothing jYHaplogroup jS
+    ++ allNothing jEndogenous jS
+    ++ allNothing jUDG jS
+    ++ allNothing jDamage jS
+    ++ allNothing jNuclearContam jS
+    ++ allNothing jNuclearContamErr jS
+    ++ allNothing jMTContam jS
+    ++ allNothing jMTContamErr jS
+    ++ allNothing jPrimaryContact jS
+    ++ allNothing jPublication jS
+    ++ allNothing jComments jS
+    ++ allNothing jKeywords jS
 
-allNothing :: (PoseidonSample -> Maybe a) -> [PoseidonSample] -> String
-allNothing column jannoSamples =
-    if all (isNothing . column) jannoSamples
+allNothing :: (JannoRow -> Maybe a) -> [JannoRow] -> String
+allNothing column jannoRows =
+    if all (isNothing . column) jannoRows
         then "."
         else "X"

--- a/src/Poseidon/CLI/Survey.hs
+++ b/src/Poseidon/CLI/Survey.hs
@@ -3,7 +3,7 @@
 module Poseidon.CLI.Survey where
 
 import           Poseidon.GenotypeData (GenotypeDataSpec (..))
-import           Poseidon.Janno        (Janno (..), PoseidonSample (..))
+import           Poseidon.Janno        (JannoRow (..))
 import           Poseidon.Package      (PoseidonPackage (..),
                                         readPoseidonPackageCollection)
 import           Poseidon.BibFile      (BibTeX (..))

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -2,8 +2,7 @@
 
 module Poseidon.Utils (
     PoseidonException(..),
-    renderPoseidonException,
-    IndividualInfo(..)
+    renderPoseidonException
 ) where
 
 import           Control.Exception (Exception)
@@ -65,21 +64,3 @@ renderPoseidonException PoseidonEmptyForgeException =
 renderPoseidonException (PoseidonNewPackageConstructionException s) =
     show s
 
-
-data IndividualInfo = IndividualInfo
-    { indInfoName    :: String
-    , indInfoGroup   :: String
-    , indInfoPacName :: String
-    }
-
-instance ToJSON IndividualInfo where
-    toJSON x = object [
-        "name" .= indInfoName x,
-        "group" .= indInfoGroup x,
-        "pacName" .= indInfoPacName x]
-
-instance FromJSON IndividualInfo where
-    parseJSON = withObject "IndividualInfo" $ \v -> IndividualInfo
-        <$> v .:   "name"
-        <*> v .:   "group"
-        <*> v .:  "pacName"

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -29,6 +29,7 @@ data PoseidonException =
     | PoseidonEmptyForgeException -- ^ An exception to throw if there is nothing to be forged
     | PoseidonNewPackageConstructionException String -- ^ An exception to indicate an issue in newPackageTemplate
     | PoseidonRemoteJSONParsingException String -- ^ An exception to indicate failed remote info JSON parsing
+    | PoseidonGenericException String -- ^ A catch-all for any other type of exception
     deriving (Show)
 
 instance Exception PoseidonException
@@ -64,6 +65,7 @@ renderPoseidonException PoseidonEmptyForgeException =
     "Nothing to be forged"
 renderPoseidonException (PoseidonNewPackageConstructionException s) =
     show s
+renderPoseidonException (PoseidonGenericException s) = show s
 
 data IndividualInfo = IndividualInfo
     { indInfoName    :: String

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -65,7 +65,7 @@ renderPoseidonException PoseidonEmptyForgeException =
     "Nothing to be forged"
 renderPoseidonException (PoseidonNewPackageConstructionException s) =
     show s
-renderPoseidonException (PoseidonGenericException s) = show s
+renderPoseidonException (PoseidonGenericException s) = s
 
 data IndividualInfo = IndividualInfo
     { indInfoName    :: String

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -2,7 +2,8 @@
 
 module Poseidon.Utils (
     PoseidonException(..),
-    renderPoseidonException
+    renderPoseidonException,
+    IndividualInfo(..)
 ) where
 
 import           Control.Exception (Exception)
@@ -64,3 +65,20 @@ renderPoseidonException PoseidonEmptyForgeException =
 renderPoseidonException (PoseidonNewPackageConstructionException s) =
     show s
 
+data IndividualInfo = IndividualInfo
+    { indInfoName    :: String
+    , indInfoGroup   :: String
+    , indInfoPacName :: String
+    }
+
+instance ToJSON IndividualInfo where
+    toJSON x = object [
+        "name" .= indInfoName x,
+        "group" .= indInfoGroup x,
+        "pacName" .= indInfoPacName x]
+
+instance FromJSON IndividualInfo where
+    parseJSON = withObject "IndividualInfo" $ \v -> IndividualInfo
+        <$> v .:   "name"
+        <*> v .:   "group"
+        <*> v .:  "pacName"

--- a/test/Poseidon/ForgeSpec.hs
+++ b/test/Poseidon/ForgeSpec.hs
@@ -3,7 +3,7 @@ module Poseidon.ForgeSpec (spec) where
 import           Poseidon.CLI.Forge
 import           Poseidon.EntitiesList       (PoseidonEntity (..), 
                                              EntitiesList (..))
-import           Poseidon.Janno             (PoseidonSample (..),
+import           Poseidon.Janno             (JannoRow (..),
                                              readJannoFile,
                                              createMinimalJanno)
 import           Poseidon.Package           (PoseidonPackage (..),
@@ -70,7 +70,7 @@ testFilterJannoFiles =
         let pacNames = map posPacTitle rps
         let jannos = map posPacJanno rps
         let filteredJannos = filterJannoFiles goodEntities $ zip pacNames jannos
-        map posSamIndividualID filteredJannos `shouldMatchList` [
+        map jIndividualID filteredJannos `shouldMatchList` [
                 -- Schiffels 2016
                 "XXX001", "XXX002", "XXX003", "XXX004", "XXX005",
                 "XXX006", "XXX007", "XXX008", "XXX009", "XXX010",

--- a/test/Poseidon/JannoSpec.hs
+++ b/test/Poseidon/JannoSpec.hs
@@ -1,6 +1,6 @@
 module Poseidon.JannoSpec (spec) where
 
-import           Poseidon.Janno            (PoseidonSample (..),
+import           Poseidon.Janno            (JannoRow (..),
                                             Sex (..),
                                             Latitude (..),
                                             Longitude (..),
@@ -34,44 +34,44 @@ testPoseidonSampleFromJannoFile = describe "Poseidon.Janno.readJannoFile" $ do
         janno_partial <- readJannoFile minimalPartialJannoPath
         janno `shouldBe` janno_partial
         length janno `shouldBe` 3
-        map posSamIndividualID janno   `shouldBe` ["XXX011", "XXX012", "XXX013"]
-        map posSamCollectionID janno   `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamSourceTissue janno   `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamLatitude janno       `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamLongitude janno      `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamDateC14UncalBP janno `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamDateBCADMedian janno `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamDateType janno       `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamDataType janno       `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamGenotypePloidy janno `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamGroupName janno      `shouldBe` [["POP1"], ["POP2"], ["POP1"]]
-        map posSamGeneticSex janno     `shouldBe` [Male, Female, Male]
-        map posSamCoverage1240K janno  `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamUDG janno            `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamLibraryBuilt janno   `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamDamage janno         `shouldBe` [Nothing, Nothing, Nothing]
+        map jIndividualID janno   `shouldBe` ["XXX011", "XXX012", "XXX013"]
+        map jCollectionID janno   `shouldBe` [Nothing, Nothing, Nothing]
+        map jSourceTissue janno   `shouldBe` [Nothing, Nothing, Nothing]
+        map jLatitude janno       `shouldBe` [Nothing, Nothing, Nothing]
+        map jLongitude janno      `shouldBe` [Nothing, Nothing, Nothing]
+        map jDateC14UncalBP janno `shouldBe` [Nothing, Nothing, Nothing]
+        map jDateBCADMedian janno `shouldBe` [Nothing, Nothing, Nothing]
+        map jDateType janno       `shouldBe` [Nothing, Nothing, Nothing]
+        map jDataType janno       `shouldBe` [Nothing, Nothing, Nothing]
+        map jGenotypePloidy janno `shouldBe` [Nothing, Nothing, Nothing]
+        map jGroupName janno      `shouldBe` [["POP1"], ["POP2"], ["POP1"]]
+        map jGeneticSex janno     `shouldBe` [Male, Female, Male]
+        map jCoverage1240K janno  `shouldBe` [Nothing, Nothing, Nothing]
+        map jUDG janno            `shouldBe` [Nothing, Nothing, Nothing]
+        map jLibraryBuilt janno   `shouldBe` [Nothing, Nothing, Nothing]
+        map jDamage janno         `shouldBe` [Nothing, Nothing, Nothing]
     it "should read normal janno files correctly" $ do
         janno <- readJannoFile normalFullJannoPath
         janno_partial <- readJannoFile normalPartialJannoPath
         janno `shouldBe` janno_partial
         length janno `shouldBe` 3
-        map posSamIndividualID janno   `shouldBe` ["XXX011", "XXX012", "XXX013"]
-        map posSamCollectionID janno   `shouldBe` [Nothing, Nothing, Nothing]
-        map posSamSourceTissue janno   `shouldBe` [Just ["xxx", "yyy"], Just ["xxx"], Just ["xxx"]]
-        map posSamCountry janno        `shouldBe` [Just "xxx", Just "xxx", Just "xxx"]
-        map posSamLatitude janno       `shouldBe` [Just (Latitude 0), Just (Latitude (-90)), Just (Latitude 90)]
-        map posSamLongitude janno      `shouldBe` [Just (Longitude 0), Just (Longitude (-180)), Just (Longitude 180)]
-        map posSamDateC14UncalBP janno `shouldBe` [Just [3000, 3100, 2900], Nothing, Nothing]
-        map posSamDateBCADMedian janno `shouldBe` [Just (-1000), Just (-5000), Just 2000]
-        map posSamDateType janno       `shouldBe` [Just C14, Just Contextual, Just Modern]
-        map posSamDataType janno       `shouldBe` [Just [Shotgun, A1240K], Just [A1240K], Just [ReferenceGenome]]
-        map posSamGenotypePloidy janno `shouldBe` [Just Diploid, Just Haploid, Just Diploid]
-        map posSamGroupName janno      `shouldBe` [["POP1", "POP3"], ["POP2"], ["POP1"]]
-        map posSamGeneticSex janno     `shouldBe` [Male, Female, Male]
-        map posSamCoverage1240K janno  `shouldBe` [Just 0, Just 0, Just 0]
-        map posSamUDG janno            `shouldBe` [Just Minus, Just Half, Just Plus]
-        map posSamLibraryBuilt janno   `shouldBe` [Just DS, Just SS, Just Other]
-        map posSamDamage janno         `shouldBe` [Just (Percent 0), Just (Percent 100), Just (Percent 50)]
+        map jIndividualID janno   `shouldBe` ["XXX011", "XXX012", "XXX013"]
+        map jCollectionID janno   `shouldBe` [Nothing, Nothing, Nothing]
+        map jSourceTissue janno   `shouldBe` [Just ["xxx", "yyy"], Just ["xxx"], Just ["xxx"]]
+        map jCountry janno        `shouldBe` [Just "xxx", Just "xxx", Just "xxx"]
+        map jLatitude janno       `shouldBe` [Just (Latitude 0), Just (Latitude (-90)), Just (Latitude 90)]
+        map jLongitude janno      `shouldBe` [Just (Longitude 0), Just (Longitude (-180)), Just (Longitude 180)]
+        map jDateC14UncalBP janno `shouldBe` [Just [3000, 3100, 2900], Nothing, Nothing]
+        map jDateBCADMedian janno `shouldBe` [Just (-1000), Just (-5000), Just 2000]
+        map jDateType janno       `shouldBe` [Just C14, Just Contextual, Just Modern]
+        map jDataType janno       `shouldBe` [Just [Shotgun, A1240K], Just [A1240K], Just [ReferenceGenome]]
+        map jGenotypePloidy janno `shouldBe` [Just Diploid, Just Haploid, Just Diploid]
+        map jGroupName janno      `shouldBe` [["POP1", "POP3"], ["POP2"], ["POP1"]]
+        map jGeneticSex janno     `shouldBe` [Male, Female, Male]
+        map jCoverage1240K janno  `shouldBe` [Just 0, Just 0, Just 0]
+        map jUDG janno            `shouldBe` [Just Minus, Just Half, Just Plus]
+        map jLibraryBuilt janno   `shouldBe` [Just DS, Just SS, Just Other]
+        map jDamage janno         `shouldBe` [Just (Percent 0), Just (Percent 100), Just (Percent 50)]
     it "should fail to read borked janno files" $ do
         readJannoFile borkedFullJannoPath `shouldThrow` anyException
         readJannoFile borkedPartialJannoPath `shouldThrow` anyException


### PR DESCRIPTION
the server now has a new API called /janno_all. This API is now used in the `list` command, which enables more flexible reporting of individual data. Specifically:

```
trident list --individuals -d /path/to/repo -j Country -j Data_Type
```

now lists - in addition to the default columns - also the country and the Data_Type from the janno files.