### PR TITLE
Renamed update and made it a bit more user-friendly

### DIFF
--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -18,7 +18,7 @@ library
                         Poseidon.CLI.FStats, Poseidon.CLI.List, 
                         Poseidon.CLI.Summarise, Poseidon.CLI.Validate, Poseidon.Utils,
                         Poseidon.CLI.Survey, Poseidon.CLI.Forge, Poseidon.CLI.Init,
-                        Poseidon.CLI.Update, Poseidon.CLI.Fetch, Poseidon.CLI.Genoconvert
+                        Poseidon.CLI.Checksumupdate, Poseidon.CLI.Fetch, Poseidon.CLI.Genoconvert
     other-modules:      Paths_poseidon_hs
     hs-source-dirs:     src
     build-depends:      base >= 4.7 && < 5, sequence-formats, text, time, pipes-safe,

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -15,7 +15,7 @@ import           Poseidon.EntitiesList  (PoseidonEntity (..),
                                         poseidonEntitiesParser)
 import           Poseidon.CLI.Summarise (SummariseOptions(..), runSummarise)
 import           Poseidon.CLI.Survey    (SurveyOptions(..), runSurvey)
-import           Poseidon.CLI.Update    (runUpdate, UpdateOptions (..))
+import           Poseidon.CLI.Checksumupdate (runChecksumupdate, ChecksumupdateOptions (..))
 import           Poseidon.CLI.Validate  (ValidateOptions(..), runValidate)
 import           Poseidon.Utils         (PoseidonException (..), 
                                         renderPoseidonException)
@@ -38,7 +38,7 @@ data Options = CmdFstats FstatsOptions
     | CmdGenoconvert GenoconvertOptions
     | CmdSummarise SummariseOptions
     | CmdSurvey SurveyOptions
-    | CmdUpdate UpdateOptions
+    | CmdChecksumupdate ChecksumupdateOptions
     | CmdValidate ValidateOptions
 
 main :: IO ()
@@ -62,7 +62,7 @@ runCmd o = case o of
     CmdGenoconvert opts -> runGenoconvert opts
     CmdSummarise opts -> runSummarise opts
     CmdSurvey opts    -> runSurvey opts
-    CmdUpdate opts    -> runUpdate opts
+    CmdChecksumupdate opts -> runChecksumupdate opts
     CmdValidate opts  -> runValidate opts
 
 optParserInfo :: OP.ParserInfo Options
@@ -80,11 +80,11 @@ versionOption = OP.infoOption (showVersion version) (OP.long "version" <> OP.hel
 
 optParser :: OP.Parser Options
 optParser = OP.subparser (
+        OP.command "checksumupdate" checksumupdateOptInfo <>
         OP.command "init" initOptInfo <>
         OP.command "fetch" fetchOptInfo <>
         OP.command "forge" forgeOptInfo <>
         OP.command "genoconvert" genoconvertOptInfo <>
-        OP.command "update" updateOptInfo <>
         OP.commandGroup "Package creation and manipulation commands:"
     ) <|>
     OP.subparser (
@@ -115,7 +115,7 @@ optParser = OP.subparser (
         (OP.progDesc "Get an overview over the content of one or multiple Poseidon packages")
     surveyOptInfo = OP.info (OP.helper <*> (CmdSurvey <$> surveyOptParser))
         (OP.progDesc "Survey the degree of context information completeness for Poseidon packages")
-    updateOptInfo = OP.info (OP.helper <*> (CmdUpdate <$> updateOptParser))
+    checksumupdateOptInfo = OP.info (OP.helper <*> (CmdChecksumupdate <$> checksumupdateOptParser))
         (OP.progDesc "Update checksums in POSEIDON.yml files")
     validateOptInfo = OP.info (OP.helper <*> (CmdValidate <$> validateOptParser))
         (OP.progDesc "Check one or multiple Poseidon packages for structural correctness")
@@ -176,8 +176,8 @@ surveyOptParser :: OP.Parser SurveyOptions
 surveyOptParser = SurveyOptions <$> parseBasePaths
                                 <*> parseRawOutput
 
-updateOptParser :: OP.Parser UpdateOptions
-updateOptParser = UpdateOptions <$> parseBasePaths
+checksumupdateOptParser :: OP.Parser ChecksumupdateOptions
+checksumupdateOptParser = ChecksumupdateOptions <$> parseBasePaths
 
 validateOptParser :: OP.Parser ValidateOptions
 validateOptParser = ValidateOptions <$> parseBasePaths

--- a/src/Poseidon/CLI/Checksumupdate.hs
+++ b/src/Poseidon/CLI/Checksumupdate.hs
@@ -1,5 +1,5 @@
-module Poseidon.CLI.Update (
-    runUpdate, UpdateOptions (..),
+module Poseidon.CLI.Checksumupdate (
+    runChecksumupdate, ChecksumupdateOptions (..),
     ) where
 
 import           Poseidon.Package           (PoseidonPackage (..),
@@ -9,12 +9,12 @@ import           Poseidon.Package           (PoseidonPackage (..),
 
 import           System.IO                  (hPutStrLn, stderr)
 
-data UpdateOptions = UpdateOptions
+data ChecksumupdateOptions = ChecksumupdateOptions
     { _jaBaseDirs :: [FilePath]
     }
 
-runUpdate :: UpdateOptions -> IO ()
-runUpdate (UpdateOptions baseDirs) = do
+runChecksumupdate :: ChecksumupdateOptions -> IO ()
+runChecksumupdate (ChecksumupdateOptions baseDirs) = do
     allPackages <- readPoseidonPackageCollection True True baseDirs
     hPutStrLn stderr "Updating checksums in the packages"
     updatedPackages <- mapM updateChecksumsInPackage allPackages

--- a/src/Poseidon/CLI/Checksumupdate.hs
+++ b/src/Poseidon/CLI/Checksumupdate.hs
@@ -16,7 +16,11 @@ data ChecksumupdateOptions = ChecksumupdateOptions
 runChecksumupdate :: ChecksumupdateOptions -> IO ()
 runChecksumupdate (ChecksumupdateOptions baseDirs) = do
     allPackages <- readPoseidonPackageCollection True True baseDirs
-    hPutStrLn stderr "Updating checksums in the packages"
+    hPutStrLn stderr "Calculating checksums"
     updatedPackages <- mapM updateChecksumsInPackage allPackages
-    hPutStrLn stderr "Writing modified POSEIDON.yml files"
-    mapM_ writePoseidonPackage updatedPackages
+    if allPackages == updatedPackages
+    then do 
+        hPutStrLn stderr "All checksums were already up-to-date"
+    else do 
+        hPutStrLn stderr "Writing modified POSEIDON.yml files"
+        mapM_ writePoseidonPackage updatedPackages

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -477,32 +477,32 @@ updateChecksumsInPackage :: PoseidonPackage -> IO PoseidonPackage
 updateChecksumsInPackage pac = do
     let d = posPacBaseDir pac
     jannoChkSum <- case posPacJannoFile pac of
-        Nothing -> return Nothing
+        Nothing -> return $ posPacJannoFileChkSum pac
         Just fn -> Just <$> getChecksum (d </> fn)
     bibChkSum <- case posPacBibFile pac of
-        Nothing -> return Nothing
+        Nothing -> return $ posPacBibFileChkSum pac
         Just fn -> Just <$> getChecksum (d </> fn)
     let gd = posPacGenotypeData pac
     genoExists <- doesFileExist (d </> genoFile gd)
     genoChkSum <- if genoExists
                   then Just <$> getChecksum (d </> genoFile gd)
-                  else return Nothing
+                  else return $ genoFileChkSum gd
     snpExists <-  doesFileExist (d </> snpFile gd)
     snpChkSum <-  if snpExists
                   then Just <$> getChecksum (d </> snpFile gd)
-                  else return Nothing
+                  else return $ snpFileChkSum gd
     indExists <-  doesFileExist (d </> indFile gd)
     indChkSum <-  if indExists
                   then Just <$> getChecksum (d </> indFile gd)
-                  else return Nothing
+                  else return $ indFileChkSum gd
     return $ pac {
-        posPacBibFileChkSum = bibChkSum,
-        posPacJannoFileChkSum = jannoChkSum,
         posPacGenotypeData = gd {
             genoFileChkSum = genoChkSum,
             snpFileChkSum = snpChkSum,
             indFileChkSum = indChkSum
-        }
+        },
+        posPacJannoFileChkSum = jannoChkSum,
+        posPacBibFileChkSum = bibChkSum
     } 
 
 writePoseidonPackage :: PoseidonPackage -> IO ()


### PR DESCRIPTION
Checksums that can not be updated due to missing files are just left alone now. That makes it more easy to work with repositories where the genotype data is omitted.