### PR TITLE
ignore duplicate individuals

### DIFF
--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -65,7 +65,7 @@ main = do
     updateGlobalLogger logger (setHandlers [fh] . setLevel INFO)
     infoM logger "Server starting up. Loading packages..."
     opts@(CommandLineOptions baseDirs port ignoreGenoFiles certFiles) <- OP.customExecParser p optParserInfo
-    allPackages <- readPoseidonPackageCollection False ignoreGenoFiles baseDirs
+    allPackages <- readPoseidonPackageCollection True False ignoreGenoFiles baseDirs
     infoM logger "Checking whether zip files are missing or outdated"
     zipDict <- forM allPackages (\pac -> do
         let fn = posPacBaseDir pac <.> "zip"

--- a/src/Poseidon/CLI/Checksumupdate.hs
+++ b/src/Poseidon/CLI/Checksumupdate.hs
@@ -1,5 +1,5 @@
-module Poseidon.CLI.Update (
-    runUpdate, UpdateOptions (..),
+module Poseidon.CLI.Checksumupdate (
+    runChecksumupdate, ChecksumupdateOptions (..),
     ) where
 
 import           Poseidon.Package           (PoseidonPackage (..),
@@ -9,14 +9,18 @@ import           Poseidon.Package           (PoseidonPackage (..),
 
 import           System.IO                  (hPutStrLn, stderr)
 
-data UpdateOptions = UpdateOptions
+data ChecksumupdateOptions = ChecksumupdateOptions
     { _jaBaseDirs :: [FilePath]
     }
 
-runUpdate :: UpdateOptions -> IO ()
-runUpdate (UpdateOptions baseDirs) = do
+runChecksumupdate :: ChecksumupdateOptions -> IO ()
+runChecksumupdate (ChecksumupdateOptions baseDirs) = do
     allPackages <- readPoseidonPackageCollection True True True baseDirs
-    hPutStrLn stderr "Updating checksums in the packages"
+    hPutStrLn stderr "Calculating checksums"
     updatedPackages <- mapM updateChecksumsInPackage allPackages
-    hPutStrLn stderr "Writing modified POSEIDON.yml files"
-    mapM_ writePoseidonPackage updatedPackages
+    if allPackages == updatedPackages
+    then do 
+        hPutStrLn stderr "All checksums were already up-to-date"
+    else do 
+        hPutStrLn stderr "Writing modified POSEIDON.yml files"
+        mapM_ writePoseidonPackage updatedPackages

--- a/src/Poseidon/CLI/FStats.hs
+++ b/src/Poseidon/CLI/FStats.hs
@@ -218,7 +218,7 @@ getPopIndices indEntries popSpec =
 runFstats :: FstatsOptions -> IO ()
 runFstats (FstatsOptions baseDirs jackknifeMode exclusionList statSpecsDirect maybeStatSpecsFile rawOutput) = do
     -- load packages --
-    allPackages <- readPoseidonPackageCollection True False baseDirs
+    allPackages <- readPoseidonPackageCollection True True False baseDirs
     statSpecsFromFile <- case maybeStatSpecsFile of
         Nothing -> return []
         Just f -> readStatSpecsFromFile f

--- a/src/Poseidon/CLI/Fetch.hs
+++ b/src/Poseidon/CLI/Fetch.hs
@@ -62,7 +62,7 @@ runFetch (FetchOptions baseDirs entitiesDirect entitiesFile remoteURL upgrade do
     let entities = nub $ entitiesDirect ++ entitiesFromFile --this nub could also be relevant for forge
         desiredPacsTitles = entities2PacTitles entities -- this whole mechanism can be replaced when the server also returns the individuals and groups in a package
     -- load local packages
-    allLocalPackages <- readPoseidonPackageCollection True False baseDirs
+    allLocalPackages <- readPoseidonPackageCollection False True False baseDirs
     -- load remote package list
     hPutStrLn stderr "Downloading package list from remote"
     remoteOverviewJSONByteString <- simpleHttp (remote ++ "/packages")

--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -60,7 +60,7 @@ runForge (ForgeOptions baseDirs entitiesDirect entitiesFile intersect outPath ou
         Just f  -> readEntitiesFromFile f
     let entities = entitiesDirect ++ entitiesFromFile
     -- load packages --
-    allPackages <- readPoseidonPackageCollection True False baseDirs
+    allPackages <- readPoseidonPackageCollection True True False baseDirs
     -- check for entities that do not exist this this dataset
     nonExistentEntities <- findNonExistentEntities entities allPackages
     unless (null nonExistentEntities) $

--- a/src/Poseidon/CLI/Genoconvert.hs
+++ b/src/Poseidon/CLI/Genoconvert.hs
@@ -33,7 +33,7 @@ data GenoconvertOptions = GenoconvertOptions
 runGenoconvert :: GenoconvertOptions -> IO ()
 runGenoconvert (GenoconvertOptions baseDirs outFormat removeOld) = do
     -- load packages
-    allPackages <- readPoseidonPackageCollection True False baseDirs
+    allPackages <- readPoseidonPackageCollection True True False baseDirs
     -- convert
     mapM_ (convertGenoTo outFormat removeOld) allPackages
 

--- a/src/Poseidon/CLI/List.hs
+++ b/src/Poseidon/CLI/List.hs
@@ -45,7 +45,7 @@ runList (ListOptions repoLocation listEntity rawOutput ignoreGeno) = do
             remoteOverviewJSONByteString <- simpleHttp (remoteURL ++ "/janno_all")
             readSampleInfo remoteOverviewJSONByteString
         RepoLocal baseDirs -> do
-            allPackages <- readPoseidonPackageCollection True ignoreGeno baseDirs
+            allPackages <- readPoseidonPackageCollection False True ignoreGeno baseDirs
             return [(posPacTitle pac, posPacJanno pac) | pac <- allPackages]
     -- construct output
     hPutStrLn stderr "Preparing output table"

--- a/src/Poseidon/CLI/Summarise.hs
+++ b/src/Poseidon/CLI/Summarise.hs
@@ -22,7 +22,7 @@ data SummariseOptions = SummariseOptions
 -- | The main function running the janno command
 runSummarise :: SummariseOptions -> IO ()
 runSummarise (SummariseOptions baseDirs rawOutput) = do
-    allPackages <- readPoseidonPackageCollection True True baseDirs
+    allPackages <- readPoseidonPackageCollection False True True baseDirs
     let jannos = map posPacJanno allPackages
     summariseJannoRows (concat jannos) rawOutput
 

--- a/src/Poseidon/CLI/Survey.hs
+++ b/src/Poseidon/CLI/Survey.hs
@@ -25,7 +25,7 @@ data SurveyOptions = SurveyOptions
 -- | The main function running the janno command
 runSurvey :: SurveyOptions -> IO ()
 runSurvey (SurveyOptions baseDirs rawOutput) = do
-    allPackages <- readPoseidonPackageCollection True True baseDirs
+    allPackages <- readPoseidonPackageCollection False True True baseDirs
     -- collect information
     let packageNames = map posPacTitle allPackages
     -- geno

--- a/src/Poseidon/CLI/Validate.hs
+++ b/src/Poseidon/CLI/Validate.hs
@@ -20,7 +20,7 @@ data ValidateOptions = ValidateOptions
 runValidate :: ValidateOptions -> IO ()
 runValidate (ValidateOptions baseDirs ignoreGeno) = do
     posFiles <- concat <$> mapM findAllPoseidonYmlFiles baseDirs
-    allPackages <- readPoseidonPackageCollection False ignoreGeno baseDirs
+    allPackages <- readPoseidonPackageCollection True False ignoreGeno baseDirs
     let numberOfPOSEIDONymlFiles = length posFiles
         numberOfLoadedPackagesWithDuplicates = foldl' (+) 0 $ map posPacDuplicate allPackages
     if numberOfPOSEIDONymlFiles == numberOfLoadedPackagesWithDuplicates

--- a/test/Poseidon/ForgeSpec.hs
+++ b/test/Poseidon/ForgeSpec.hs
@@ -41,11 +41,11 @@ testFindNonExistentEntities :: Spec
 testFindNonExistentEntities = 
     describe "Poseidon.CLI.Forge.findNonExistentEntities" $ do
     it "should ignore good entities" $ do
-        ps <- readPoseidonPackageCollection False False testBaseDir
+        ps <- readPoseidonPackageCollection True False False testBaseDir
         ents <- findNonExistentEntities goodEntities ps  
         ents `shouldBe` []
     it "should find bad entities" $ do
-        ps <- readPoseidonPackageCollection False False testBaseDir
+        ps <- readPoseidonPackageCollection True False False testBaseDir
         ents <- findNonExistentEntities badEntities ps  
         ents `shouldMatchList` badEntities
 
@@ -53,11 +53,11 @@ testFilterPackages :: Spec
 testFilterPackages = 
     describe "Poseidon.CLI.Forge.filterPackages" $ do
     it "should select all relevant packages" $ do
-        ps <- readPoseidonPackageCollection False False testBaseDir
+        ps <- readPoseidonPackageCollection True False False testBaseDir
         pacs <- filterPackages goodEntities ps  
         map posPacTitle pacs `shouldMatchList` ["Schiffels_2016", "Wang_Plink_test_2020", "Lamnidis_2018"]
     it "should drop all irrelevant packages" $ do
-        ps <- readPoseidonPackageCollection False False testBaseDir
+        ps <- readPoseidonPackageCollection True False False testBaseDir
         pacs <- filterPackages badEntities ps
         pacs `shouldBe` []
 
@@ -65,7 +65,7 @@ testFilterJannoFiles :: Spec
 testFilterJannoFiles = 
     describe "Poseidon.CLI.Forge.filterJannoFiles" $ do
     it "should select all relevant individuals" $ do
-        ps <- readPoseidonPackageCollection False False testBaseDir
+        ps <- readPoseidonPackageCollection True False False testBaseDir
         rps <- filterPackages goodEntities ps
         let pacNames = map posPacTitle rps
         let jannos = map posPacJanno rps
@@ -80,7 +80,7 @@ testFilterJannoFiles =
                 "SAMPLE3"
             ]
     it "should drop all irrelevant individuals" $ do
-        ps <- readPoseidonPackageCollection False False testBaseDir
+        ps <- readPoseidonPackageCollection True False False testBaseDir
         rps <- filterPackages badEntities ps
         let pacNames = map posPacTitle rps
         let jannos = map posPacJanno rps
@@ -91,10 +91,10 @@ testExtractEntityIndices :: Spec
 testExtractEntityIndices = 
     describe "Poseidon.CLI.Forge.extractEntityIndices" $ do
     it "should select all relevant individuals" $ do
-        ps <- readPoseidonPackageCollection False False testBaseDir
+        ps <- readPoseidonPackageCollection True False False testBaseDir
         indInts <- extractEntityIndices goodEntities ps  
         indInts `shouldMatchList` [0, 2, 6, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 23]
     it "should drop all irrelevant individuals" $ do
-        ps <- readPoseidonPackageCollection False False testBaseDir
+        ps <- readPoseidonPackageCollection True False False testBaseDir
         indInts <- extractEntityIndices badEntities ps
         indInts `shouldBe` []

--- a/test/Poseidon/PackageSpec.hs
+++ b/test/Poseidon/PackageSpec.hs
@@ -29,7 +29,7 @@ import           Text.RawString.QQ
 
 spec = do
     testPoseidonFromYAML
-    testReadPoseidonPackageCollection
+    testreadPoseidonPackageCollection
     testGetChecksum
     testRenderMismatch
     testZipWithPadding
@@ -141,11 +141,11 @@ testPoseidonFromYAML = describe "PoseidonPackage.fromYAML" $ do
     it "should fail with lastModified missing" $ do
         p `shouldBe` truePackageRelPaths {_posYamlLastModified = Nothing}
 
-testReadPoseidonPackageCollection :: Spec
-testReadPoseidonPackageCollection = describe "PoseidonPackage.findPoseidonPackages" $ do
+testreadPoseidonPackageCollection :: Spec
+testreadPoseidonPackageCollection = describe "PoseidonPackage.findPoseidonPackages" $ do
     let dir = "test/testDat/testModules/ancient"
     it "should discover packages correctly" $ do
-        pac <- readPoseidonPackageCollection False False [dir]
+        pac <- readPoseidonPackageCollection True False False [dir]
         sort (map posPacTitle pac) `shouldBe` ["Lamnidis_2018", "Schiffels_2016", "Wang_Plink_test_2020"]
         sort (map posPacLastModified pac) `shouldBe` [Just (fromGregorian 2020 2 20),
                                                       Just (fromGregorian 2020 2 28),


### PR DESCRIPTION
This adds an option to `readPoseidonPackageCollection` to not halt on duplicate individuals. 

I activated it for `fetch`, `list`, `summarise` and `survey` as proposed in #64.