### PR TITLE
Verbose janno reading

### DIFF
--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -65,7 +65,7 @@ main = do
     updateGlobalLogger logger (setHandlers [fh] . setLevel INFO)
     infoM logger "Server starting up. Loading packages..."
     opts@(CommandLineOptions baseDirs port ignoreGenoFiles certFiles) <- OP.customExecParser p optParserInfo
-    allPackages <- readPoseidonPackageCollection True False ignoreGenoFiles True baseDirs
+    allPackages <- readPoseidonPackageCollection False True False ignoreGenoFiles True baseDirs
     infoM logger "Checking whether zip files are missing or outdated"
     zipDict <- if ignoreGenoFiles then return [] else forM allPackages (\pac -> do
         let fn = posPacBaseDir pac <.> "zip"

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -181,6 +181,7 @@ checksumupdateOptParser = ChecksumupdateOptions <$> parseBasePaths
 
 validateOptParser :: OP.Parser ValidateOptions
 validateOptParser = ValidateOptions <$> parseBasePaths
+                                    <*> parseVerbose
                                     <*> parseIgnoreGeno
 
 parseJackknife :: OP.Parser JackknifeMode
@@ -339,6 +340,12 @@ parseRawOutput :: OP.Parser Bool
 parseRawOutput = OP.switch (
     OP.long "raw" <> 
     OP.help "output table as tsv without header. Useful for piping into grep or awk"
+    )
+
+parseVerbose :: OP.Parser Bool
+parseVerbose = OP.switch (
+    OP.long "verbose" <>
+    OP.help "print more output to the command line"
     )
 
 parseIgnoreGeno :: OP.Parser Bool

--- a/src/Poseidon/CLI/Checksumupdate.hs
+++ b/src/Poseidon/CLI/Checksumupdate.hs
@@ -15,7 +15,7 @@ data ChecksumupdateOptions = ChecksumupdateOptions
 
 runChecksumupdate :: ChecksumupdateOptions -> IO ()
 runChecksumupdate (ChecksumupdateOptions baseDirs) = do
-    allPackages <- readPoseidonPackageCollection True True True False baseDirs
+    allPackages <- readPoseidonPackageCollection False True True True False baseDirs
     hPutStrLn stderr "Calculating checksums"
     updatedPackages <- mapM updateChecksumsInPackage allPackages
     if allPackages == updatedPackages

--- a/src/Poseidon/CLI/FStats.hs
+++ b/src/Poseidon/CLI/FStats.hs
@@ -218,7 +218,7 @@ getPopIndices indEntries popSpec =
 runFstats :: FstatsOptions -> IO ()
 runFstats (FstatsOptions baseDirs jackknifeMode exclusionList statSpecsDirect maybeStatSpecsFile rawOutput) = do
     -- load packages --
-    allPackages <- readPoseidonPackageCollection True True False True baseDirs
+    allPackages <- readPoseidonPackageCollection False True True False True baseDirs
     statSpecsFromFile <- case maybeStatSpecsFile of
         Nothing -> return []
         Just f -> readStatSpecsFromFile f

--- a/src/Poseidon/CLI/Fetch.hs
+++ b/src/Poseidon/CLI/Fetch.hs
@@ -60,7 +60,7 @@ runFetch (FetchOptions baseDirs entitiesDirect entitiesFile remoteURL upgrade do
     let entities = nub $ entitiesDirect ++ concat entitiesFromFile --this nub could also be relevant for forge
         desiredPacsTitles = entities2PacTitles entities -- this whole mechanism can be replaced when the server also returns the individuals and groups in a package
     -- load local packages
-    allLocalPackages <- readPoseidonPackageCollection False True False False baseDirs
+    allLocalPackages <- readPoseidonPackageCollection False False True False False baseDirs
     -- load remote package list
     hPutStrLn stderr "Downloading package list from remote"
     remoteOverviewJSONByteString <- simpleHttp (remote ++ "/packages")

--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -58,7 +58,7 @@ runForge (ForgeOptions baseDirs entitiesDirect entitiesFile intersect outPath ou
     entitiesFromFile <- mapM readEntitiesFromFile entitiesFile
     let entities = nub $ entitiesDirect ++ concat entitiesFromFile
     -- load packages --
-    allPackages <- readPoseidonPackageCollection False True False True baseDirs
+    allPackages <- readPoseidonPackageCollection False False True False True baseDirs
     -- check for entities that do not exist this this dataset
     nonExistentEntities <- findNonExistentEntities entities allPackages
     unless (null nonExistentEntities) $

--- a/src/Poseidon/CLI/Genoconvert.hs
+++ b/src/Poseidon/CLI/Genoconvert.hs
@@ -33,7 +33,7 @@ data GenoconvertOptions = GenoconvertOptions
 runGenoconvert :: GenoconvertOptions -> IO ()
 runGenoconvert (GenoconvertOptions baseDirs outFormat removeOld) = do
     -- load packages
-    allPackages <- readPoseidonPackageCollection True True False True baseDirs
+    allPackages <- readPoseidonPackageCollection False True True False True baseDirs
     -- convert
     mapM_ (convertGenoTo outFormat removeOld) allPackages
 

--- a/src/Poseidon/CLI/List.hs
+++ b/src/Poseidon/CLI/List.hs
@@ -45,7 +45,7 @@ runList (ListOptions repoLocation listEntity rawOutput ignoreGeno) = do
             remoteOverviewJSONByteString <- simpleHttp (remoteURL ++ "/janno_all")
             readSampleInfo remoteOverviewJSONByteString
         RepoLocal baseDirs -> do
-            allPackages <- readPoseidonPackageCollection False True ignoreGeno False baseDirs
+            allPackages <- readPoseidonPackageCollection False False True ignoreGeno False baseDirs
             return [(posPacTitle pac, posPacJanno pac) | pac <- allPackages]
     -- construct output
     hPutStrLn stderr "Preparing output table"

--- a/src/Poseidon/CLI/Summarise.hs
+++ b/src/Poseidon/CLI/Summarise.hs
@@ -22,7 +22,7 @@ data SummariseOptions = SummariseOptions
 -- | The main function running the janno command
 runSummarise :: SummariseOptions -> IO ()
 runSummarise (SummariseOptions baseDirs rawOutput) = do
-    allPackages <- readPoseidonPackageCollection False True True False baseDirs
+    allPackages <- readPoseidonPackageCollection False False True True False baseDirs
     let jannos = map posPacJanno allPackages
     summariseJannoRows (concat jannos) rawOutput
 

--- a/src/Poseidon/CLI/Survey.hs
+++ b/src/Poseidon/CLI/Survey.hs
@@ -25,7 +25,7 @@ data SurveyOptions = SurveyOptions
 -- | The main function running the janno command
 runSurvey :: SurveyOptions -> IO ()
 runSurvey (SurveyOptions baseDirs rawOutput) = do
-    allPackages <- readPoseidonPackageCollection False True True False baseDirs
+    allPackages <- readPoseidonPackageCollection False False True True False baseDirs
     -- collect information
     let packageNames = map posPacTitle allPackages
     -- geno

--- a/src/Poseidon/CLI/Validate.hs
+++ b/src/Poseidon/CLI/Validate.hs
@@ -26,7 +26,7 @@ data ValidateOptions = ValidateOptions
 runValidate :: ValidateOptions -> IO ()
 runValidate (ValidateOptions baseDirs ignoreGeno) = do
     posFiles <- concat <$> mapM findAllPoseidonYmlFiles baseDirs
-    allPackages <- readPoseidonPackageCollection True False ignoreGeno True baseDirs
+    allPackages <- readPoseidonPackageCollection False True False ignoreGeno True baseDirs
     let numberOfPOSEIDONymlFiles = length posFiles
         numberOfLoadedPackagesWithDuplicates = foldl' (+) 0 $ map posPacDuplicate allPackages
     check <- if numberOfPOSEIDONymlFiles == numberOfLoadedPackagesWithDuplicates

--- a/src/Poseidon/CLI/Validate.hs
+++ b/src/Poseidon/CLI/Validate.hs
@@ -20,13 +20,14 @@ import           System.IO         (hPutStrLn, stderr)
 -- | A datatype representing command line options for the validate command
 data ValidateOptions = ValidateOptions
     { _jaBaseDirs    :: [FilePath]
+    , _optVerbose    :: Bool
     , _optIgnoreGeno :: Bool
     }
 
 runValidate :: ValidateOptions -> IO ()
-runValidate (ValidateOptions baseDirs ignoreGeno) = do
+runValidate (ValidateOptions baseDirs verbose ignoreGeno) = do
     posFiles <- concat <$> mapM findAllPoseidonYmlFiles baseDirs
-    allPackages <- readPoseidonPackageCollection False True False ignoreGeno True baseDirs
+    allPackages <- readPoseidonPackageCollection verbose True False ignoreGeno True baseDirs
     let numberOfPOSEIDONymlFiles = length posFiles
         numberOfLoadedPackagesWithDuplicates = foldl' (+) 0 $ map posPacDuplicate allPackages
     check <- if numberOfPOSEIDONymlFiles == numberOfLoadedPackagesWithDuplicates

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -380,7 +380,7 @@ readPoseidonPackageCollection verbose stopOnDuplicates ignoreChecksums ignoreGen
     posFiles <- concat <$> mapM findAllPoseidonYmlFiles dirs
     hPutStrLn stderr $ show (length posFiles) ++ " found"
     hPutStrLn stderr "Initializing packages... "
-    eitherPackages <- mapM tryDecodePoseidonPackage $ zip [1..] posFiles
+    eitherPackages <- mapM (tryDecodePoseidonPackage verbose) $ zip [1..] posFiles
     hPutStrLn stderr ""
     -- notifying the users of package problems
     when (not . null . lefts $ eitherPackages) $ do
@@ -407,12 +407,15 @@ readPoseidonPackageCollection verbose stopOnDuplicates ignoreChecksums ignoreGen
     -- return package list
     return finalPackageList
   where
-    tryDecodePoseidonPackage :: (Integer, FilePath) -> IO (Either PoseidonException PoseidonPackage)
-    tryDecodePoseidonPackage (numberPackage, path) = do
+    tryDecodePoseidonPackage :: Bool -> (Integer, FilePath) -> IO (Either PoseidonException PoseidonPackage)
+    tryDecodePoseidonPackage False (numberPackage, path) = do
         hClearLine stderr
         hSetCursorColumn stderr 0
         hPutStr stderr $ "> " ++ show numberPackage ++ " "
         hFlush stderr
+        try . readPoseidonPackage verbose ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes $ path
+    tryDecodePoseidonPackage True (numberPackage, path) = do
+        hPutStrLn stderr $ "> " ++ show numberPackage ++ ": " ++ path
         try . readPoseidonPackage verbose ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes $ path
 
 checkIndividualsUnique :: Bool -> [EigenstratIndEntry] -> IO ()

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -232,12 +232,13 @@ instance ToJSON ContributorSpec where
 
 -- | A function to read in a poseidon package from a YAML file. Note that this function calls the addFullPaths function to
 -- make paths absolute.
-readPoseidonPackage :: Bool -- ^ whether to ignore all checksums
+readPoseidonPackage :: Bool -- whether to print verbose output
+                    -> Bool -- ^ whether to ignore all checksums
                     -> Bool -- ^ whether to ignore missing genotype files, useful for developer use cases
                     -> Bool -- ^ whether to check the first 100 SNPs of the genotypes
                     -> FilePath -- ^ the file path to the yaml file
                     -> IO PoseidonPackage -- ^ the returning package returned in the IO monad.
-readPoseidonPackage ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes ymlPath = do
+readPoseidonPackage verbose ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes ymlPath = do
     let baseDir = takeDirectory ymlPath
     bs <- B.readFile ymlPath
     -- read yml files
@@ -253,7 +254,7 @@ readPoseidonPackage ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes ym
         Nothing -> do
             return $ createMinimalJanno indEntries
         Just p -> do
-            loadedJanno <- readJannoFile p
+            loadedJanno <- readJannoFile verbose p
             checkJannoIndConsistency tit loadedJanno indEntries
             return loadedJanno
     -- read bib (or fill with empty list)
@@ -367,13 +368,14 @@ checkJannoBibConsistency pacName janno bibtex = do
 -- | a utility function to load all poseidon packages found recursively in multiple base directories. 
 -- This also takes care of smart filtering and duplication checks. Exceptions lead to skipping packages and outputting
 -- warnings
-readPoseidonPackageCollection :: Bool -- ^ whether to stop on duplicated individuals
+readPoseidonPackageCollection :: Bool -- whether to print verbose output
+                              -> Bool -- ^ whether to stop on duplicated individuals
                               -> Bool -- ^ whether to ignore all checksums
                               -> Bool -- ^ whether to ignore missing genotype files, useful for developer use cases
                               -> Bool -- ^ whether to check the top 100 SNPs of the genotype data
                               -> [FilePath] -- ^ A list of base directories where to search in
                               -> IO [PoseidonPackage] -- ^ A list of returned poseidon packages.
-readPoseidonPackageCollection stopOnDuplicates ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes dirs = do
+readPoseidonPackageCollection verbose stopOnDuplicates ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes dirs = do
     hPutStr stderr $ "Searching POSEIDON.yml files... "
     posFiles <- concat <$> mapM findAllPoseidonYmlFiles dirs
     hPutStrLn stderr $ show (length posFiles) ++ " found"
@@ -411,7 +413,7 @@ readPoseidonPackageCollection stopOnDuplicates ignoreChecksums ignoreGenotypeFil
         hSetCursorColumn stderr 0
         hPutStr stderr $ "> " ++ show numberPackage ++ " "
         hFlush stderr
-        try . readPoseidonPackage ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes $ path
+        try . readPoseidonPackage verbose ignoreChecksums ignoreGenotypeFilesMissing checkGenotypes $ path
 
 checkIndividualsUnique :: Bool -> [EigenstratIndEntry] -> IO ()
 checkIndividualsUnique stopOnDuplicates indEntries = do

--- a/test/Poseidon/ForgeSpec.hs
+++ b/test/Poseidon/ForgeSpec.hs
@@ -41,11 +41,11 @@ testFindNonExistentEntities :: Spec
 testFindNonExistentEntities = 
     describe "Poseidon.CLI.Forge.findNonExistentEntities" $ do
     it "should ignore good entities" $ do
-        ps <- readPoseidonPackageCollection True False False False testBaseDir
+        ps <- readPoseidonPackageCollection False True False False False testBaseDir
         ents <- findNonExistentEntities goodEntities ps  
         ents `shouldBe` []
     it "should find bad entities" $ do
-        ps <- readPoseidonPackageCollection True False False False testBaseDir
+        ps <- readPoseidonPackageCollection False True False False False testBaseDir
         ents <- findNonExistentEntities badEntities ps  
         ents `shouldMatchList` badEntities
 
@@ -53,11 +53,11 @@ testFilterPackages :: Spec
 testFilterPackages = 
     describe "Poseidon.CLI.Forge.filterPackages" $ do
     it "should select all relevant packages" $ do
-        ps <- readPoseidonPackageCollection True False False False testBaseDir
+        ps <- readPoseidonPackageCollection False True False False False testBaseDir
         pacs <- filterPackages goodEntities ps  
         map posPacTitle pacs `shouldMatchList` ["Schiffels_2016", "Wang_Plink_test_2020", "Lamnidis_2018"]
     it "should drop all irrelevant packages" $ do
-        ps <- readPoseidonPackageCollection True False False False testBaseDir
+        ps <- readPoseidonPackageCollection False True False False False testBaseDir
         pacs <- filterPackages badEntities ps
         pacs `shouldBe` []
 
@@ -65,7 +65,7 @@ testFilterJannoFiles :: Spec
 testFilterJannoFiles = 
     describe "Poseidon.CLI.Forge.filterJannoFiles" $ do
     it "should select all relevant individuals" $ do
-        ps <- readPoseidonPackageCollection True False False False testBaseDir
+        ps <- readPoseidonPackageCollection False True False False False testBaseDir
         rps <- filterPackages goodEntities ps
         let pacNames = map posPacTitle rps
         let jannos = map posPacJanno rps
@@ -80,7 +80,7 @@ testFilterJannoFiles =
                 "SAMPLE3"
             ]
     it "should drop all irrelevant individuals" $ do
-        ps <- readPoseidonPackageCollection True False False False testBaseDir
+        ps <- readPoseidonPackageCollection False True False False False testBaseDir
         rps <- filterPackages badEntities ps
         let pacNames = map posPacTitle rps
         let jannos = map posPacJanno rps
@@ -91,10 +91,10 @@ testExtractEntityIndices :: Spec
 testExtractEntityIndices = 
     describe "Poseidon.CLI.Forge.extractEntityIndices" $ do
     it "should select all relevant individuals" $ do
-        ps <- readPoseidonPackageCollection True False False False testBaseDir
+        ps <- readPoseidonPackageCollection False True False False False testBaseDir
         indInts <- extractEntityIndices goodEntities ps  
         indInts `shouldMatchList` [0, 2, 6, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 23]
     it "should drop all irrelevant individuals" $ do
-        ps <- readPoseidonPackageCollection True False False False testBaseDir
+        ps <- readPoseidonPackageCollection False True False False False testBaseDir
         indInts <- extractEntityIndices badEntities ps
         indInts `shouldBe` []

--- a/test/Poseidon/JannoSpec.hs
+++ b/test/Poseidon/JannoSpec.hs
@@ -30,8 +30,8 @@ testPoseidonSampleFromJannoFile = describe "Poseidon.Janno.readJannoFile" $ do
     let borkedPartialJannoPath    = "test/testDat/testJannoFiles/borked_partial.janno"
     let borkedWrongNameJannoPath  = "test/testDat/testJannoFiles/borked_wrong_name.janno"
     it "should read minimal janno files correctly" $ do
-        janno <- readJannoFile minimalFullJannoPath
-        janno_partial <- readJannoFile minimalPartialJannoPath
+        janno <- readJannoFile False minimalFullJannoPath
+        janno_partial <- readJannoFile False minimalPartialJannoPath
         janno `shouldBe` janno_partial
         length janno `shouldBe` 3
         map jIndividualID janno   `shouldBe` ["XXX011", "XXX012", "XXX013"]
@@ -51,8 +51,8 @@ testPoseidonSampleFromJannoFile = describe "Poseidon.Janno.readJannoFile" $ do
         map jLibraryBuilt janno   `shouldBe` [Nothing, Nothing, Nothing]
         map jDamage janno         `shouldBe` [Nothing, Nothing, Nothing]
     it "should read normal janno files correctly" $ do
-        janno <- readJannoFile normalFullJannoPath
-        janno_partial <- readJannoFile normalPartialJannoPath
+        janno <- readJannoFile False normalFullJannoPath
+        janno_partial <- readJannoFile False normalPartialJannoPath
         janno `shouldBe` janno_partial
         length janno `shouldBe` 3
         map jIndividualID janno   `shouldBe` ["XXX011", "XXX012", "XXX013"]
@@ -73,6 +73,6 @@ testPoseidonSampleFromJannoFile = describe "Poseidon.Janno.readJannoFile" $ do
         map jLibraryBuilt janno   `shouldBe` [Just DS, Just SS, Just Other]
         map jDamage janno         `shouldBe` [Just (Percent 0), Just (Percent 100), Just (Percent 50)]
     it "should fail to read borked janno files" $ do
-        readJannoFile borkedFullJannoPath `shouldThrow` anyException
-        readJannoFile borkedPartialJannoPath `shouldThrow` anyException
-        readJannoFile borkedWrongNameJannoPath `shouldThrow` anyException
+        readJannoFile False borkedFullJannoPath `shouldThrow` anyException
+        readJannoFile False borkedPartialJannoPath `shouldThrow` anyException
+        readJannoFile False borkedWrongNameJannoPath `shouldThrow` anyException

--- a/test/Poseidon/PackageSpec.hs
+++ b/test/Poseidon/PackageSpec.hs
@@ -149,7 +149,7 @@ testreadPoseidonPackageCollection :: Spec
 testreadPoseidonPackageCollection = describe "PoseidonPackage.findPoseidonPackages" $ do
     let dir = "test/testDat/testModules/ancient"
     it "should discover packages correctly" $ do
-        pac <- readPoseidonPackageCollection True False False False [dir]
+        pac <- readPoseidonPackageCollection False True False False False [dir]
         sort (map posPacTitle pac) `shouldBe` ["Lamnidis_2018", "Schiffels_2016", "Wang_Plink_test_2020"]
         sort (map posPacLastModified pac) `shouldBe` [Just (fromGregorian 2020 2 20),
                                                       Just (fromGregorian 2020 2 28),

--- a/test/Poseidon/SurveySpec.hs
+++ b/test/Poseidon/SurveySpec.hs
@@ -21,12 +21,12 @@ testRenderJannoCompleteness :: Spec
 testRenderJannoCompleteness = 
     describe "Poseidon.CLI.Survey.renderJannoCompleteness" $ do
     it "should work for a full janno file" $ do
-        janno <- readJannoFile testJannoNormal
+        janno <- readJannoFile False testJannoNormal
         renderJannoCompleteness janno 
             `shouldBe` 
             "M.XXXXXXXXXXXXXXXXMMXXXXXXXXXXXXXXX"
     it "should work for a minimum janno file" $ do
-        janno <- readJannoFile testJannoMinimal
+        janno <- readJannoFile False testJannoMinimal
         renderJannoCompleteness janno
             `shouldBe`
             "M.................MM..............."


### PR DESCRIPTION
This is my suggestion for a solution to #79. Just a `--verbose` switch in `validate`, that propagates down to `readJannoFile` and triggers some more console output about additional and missing columns there.

I'm not a big fan of a `--strict` mode, as laid out in #79. I think `verbose` is sufficient to spot these kind of mistakes quickly when preparing the package.