### PR TITLE
Forge performance experiments

### DIFF
--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -35,6 +35,7 @@ executable trident
     build-depends:      base, poseidon-hs, optparse-applicative, sequence-formats>=1.6.1, bytestring
     other-modules:      Paths_poseidon_hs
     default-language:   Haskell2010
+    ghc-options:        -O2
 
 executable poseidon-http-server
     main-is:            Main-server.hs

--- a/src/Poseidon/GenotypeData.hs
+++ b/src/Poseidon/GenotypeData.hs
@@ -4,8 +4,8 @@ module Poseidon.GenotypeData where
 
 import           Poseidon.Utils             (PoseidonException (..))
 
-import           Control.Monad              (forM, void, when)
-import           Control.Monad.Catch        (MonadThrow, throwM)
+import           Control.Monad              (void, when)--(forM, void, when)
+import           Control.Monad.Catch        (throwM)--(MonadThrow, throwM)
 import           Control.Monad.IO.Class     (liftIO)
 import           Data.Aeson                 (FromJSON, ToJSON, object,
                                              parseJSON, toJSON, withObject,
@@ -228,7 +228,8 @@ getConsensusSnpEntry showAllWarnings snpEntries = do
         _ -> throwM $ PoseidonGenotypeException ("Incongruent alleles: " ++ show snpEntries)
 
 genotypes2alleles :: EigenstratSnpEntry -> GenoLine -> V.Vector (Char, Char)
-genotypes2alleles snpEntry@(EigenstratSnpEntry _ _ _ _ ref alt) = V.map g2a
+--genotypes2alleles snpEntry@(EigenstratSnpEntry _ _ _ _ ref alt) = V.map g2a
+genotypes2alleles (EigenstratSnpEntry _ _ _ _ ref alt) = V.map g2a
   where
     g2a :: GenoEntry -> (Char, Char)
     g2a HomRef =
@@ -246,7 +247,8 @@ genotypes2alleles snpEntry@(EigenstratSnpEntry _ _ _ _ ref alt) = V.map g2a
     g2a Missing = ('N', 'N')
 
 recodeAlleles :: EigenstratSnpEntry -> V.Vector (Char, Char) -> GenoLine
-recodeAlleles snpEntry@(EigenstratSnpEntry _ _ _ _ ref alt) = V.map a2g
+--recodeAlleles snpEntry@(EigenstratSnpEntry _ _ _ _ ref alt) = V.map a2g
+recodeAlleles (EigenstratSnpEntry _ _ _ _ ref alt) = V.map a2g
   where
     a2g :: (Char, Char) -> GenoEntry
     a2g (a1, a2)


### PR DESCRIPTION
Here are some experiments to increase the forge performance - imho still a major challenge to make poseidon more attractive. Especially after @TCLamnidis told me about his 77million SNP merge operation that takes him >24 hours with trident.

Skipping the nice error handling in `genotypes2alleles` and `recodeAlleles` gives us a significant boost:

```
trident forge -d . -f "<COD147>,<I6764>,<COV20126.SG>,<I13980>,<s19_X10_1.SG>" -o huhu -n huhu
```

With `MonadThrow`:
```
real	3m11,417s
user	3m11,077s
sys	0m0,324s
```

Without nice error handling (as implemented in this PR):
```
real	1m3,630s
user	1m3,465s
sys	0m0,164s
```

Here's the profiling for the first 30000 SNPs (approx.):
```
	Wed Jul 28 16:10 2021 Time and Allocation Profiling Report  (Final)

	   trident +RTS -p -RTS forge -d . -f <COD147>,<I6764>,<COV20126.SG>,<I13980>,<s19_X10_1.SG> -o huhu -n huhu

	total time  =       16.11 secs   (16114 ticks @ 1000 us, 1 processor)
	total alloc = 20,968,245,480 bytes  (excludes profiling overheads)

COST CENTRE                   MODULE                            SRC                                                    %time %alloc

recodeAlleles                 Poseidon.GenotypeData             src/Poseidon/GenotypeData.hs:(250,1)-(260,24)           18.1   23.6
genotypes2alleles             Poseidon.GenotypeData             src/Poseidon/GenotypeData.hs:(231,1)-(247,24)           17.5   23.3
>>=.\.succ'                   Data.Attoparsec.Internal.Types    Data/Attoparsec/Internal/Types.hs:148:13-76             11.2    7.5
readEitherSafe                Safe                              Safe.hs:(253,1)-(260,51)                                 4.4    5.5
>>=.\                         Data.Attoparsec.Internal.Types    Data/Attoparsec/Internal/Types.hs:(148,9)-(149,44)       4.0    1.5
fmap                          Data.Vector.Fusion.Stream.Monadic Data/Vector/Fusion/Stream/Monadic.hs:(133,3)-(135,20)    3.8    6.4
recodeAlleles.a2g             Poseidon.GenotypeData             src/Poseidon/GenotypeData.hs:(253,5)-(258,123)           3.2    0.0
primitive                     Control.Monad.Primitive           Control/Monad/Primitive.hs:210:3-16                      2.8    1.9
basicUnsafeWrite              Data.Vector.Mutable               Data/Vector/Mutable.hs:120:3-65                          2.8    4.0
>>=                           Data.Vector.Fusion.Util           Data/Vector/Fusion/Util.hs:36:3-18                       2.1    2.5
_bind.go                      Pipes.Internal                    src/Pipes/Internal.hs:(111,5)-(115,29)                   1.9    1.4
basicUnsafeSlice              Data.Vector.Mutable               Data/Vector/Mutable.hs:91:3-62                           1.4    3.2
bedGenotypeParser.indBitPairs SequenceFormats.Plink             src/SequenceFormats/Plink.hs:82:9-49                     1.3    3.4
basicUnsafeIndexM             Data.Vector                       Data/Vector.hs:290:3-62                                  1.2    1.1
genotypes2alleles.g2a         Poseidon.GenotypeData             src/Poseidon/GenotypeData.hs:(234,5)-(246,35)            1.1    0.1
writeBim.toTextPipe.\.bimLine SequenceFormats.Plink             src/SequenceFormats/Plink.hs:(137,17)-(138,72)           1.1    0.7

###################################################################################################################################

	Wed Jul 28 18:02 2021 Time and Allocation Profiling Report  (Final)

	   trident +RTS -p -RTS forge -d . -f <COD147>,<I6764>,<COV20126.SG>,<I13980>,<s19_X10_1.SG> -o huhu -n huhu

	total time  =       10.40 secs   (10401 ticks @ 1000 us, 1 processor)
	total alloc = 14,045,794,288 bytes  (excludes profiling overheads)

COST CENTRE                   MODULE                            SRC                                                    %time %alloc

>>=.\.succ'                   Data.Attoparsec.Internal.Types    Data/Attoparsec/Internal/Types.hs:148:13-76             16.8   11.1
>>=.\                         Data.Attoparsec.Internal.Types    Data/Attoparsec/Internal/Types.hs:(148,9)-(149,44)       6.3    2.2
>>=                           Data.Vector.Fusion.Util           Data/Vector/Fusion/Util.hs:36:3-18                       5.9   11.1
fmap                          Data.Vector.Fusion.Stream.Monadic Data/Vector/Fusion/Stream/Monadic.hs:(133,3)-(135,20)    5.8    9.4
readEitherSafe                Safe                              Safe.hs:(253,1)-(260,51)                                 5.8    8.1
recodeAlleles                 Poseidon.GenotypeData             src/Poseidon/GenotypeData.hs:(251,1)-(261,114)           5.4    7.2
genotypes2alleles             Poseidon.GenotypeData             src/Poseidon/GenotypeData.hs:(232,1)-(247,28)            5.0    8.5
basicUnsafeWrite              Data.Vector.Mutable               Data/Vector/Mutable.hs:120:3-65                          4.6    5.9
primitive                     Control.Monad.Primitive           Control/Monad/Primitive.hs:210:3-16                      3.8    2.8
_bind.go                      Pipes.Internal                    src/Pipes/Internal.hs:(111,5)-(115,29)                   2.8    2.0
basicUnsafeSlice              Data.Vector.Mutable               Data/Vector/Mutable.hs:91:3-62                           2.5    4.7
basicUnsafeIndexM             Data.Vector                       Data/Vector.hs:290:3-62                                  1.7    1.6
fmap.\.succ'                  Data.Attoparsec.Internal.Types    Data/Attoparsec/Internal/Types.hs:173:11-58              1.5    1.3
writeBim.toTextPipe.\.bimLine SequenceFormats.Plink             src/SequenceFormats/Plink.hs:(137,17)-(138,72)           1.5    1.1
next.go                       Pipes                             src/Pipes.hs:(631,5)-(635,39)                            1.2    0.9
>>=                           Data.Attoparsec.Internal.Types    Data/Attoparsec/Internal/Types.hs:(147,5)-(149,44)       1.1    0.0
for                           Pipes                             src/Pipes.hs:177:1-11                                    1.0    0.6
bedGenotypeParser.indBitPairs SequenceFormats.Plink             src/SequenceFormats/Plink.hs:82:9-49                     1.0    5.1
decimal.step                  Data.Attoparsec.ByteString.Char8  Data/Attoparsec/ByteString/Char8.hs:448:9-49             0.9    1.2
```

I think we should find a way to allow running this unsafe version of forge. Maybe with a flag `--unsafe` or `--fast`. Probably there is some more stuff that can be chipped away for such an option, or what do you think, @stschiff? The basic implementation is very careful, which is good in general, but I assume the error cases you're catching are in fact pretty rare. At least with the typical poseidon user stories. So there should be a way to circumvent this for more speed.

I also experimented with running `genotypes2alleles` and `recodeAlleles` in parallel with something like [this](https://stackoverflow.com/questions/47915883/parallel-mapping-over-vectors-in-haskell). Unsurprisingly the overhead is eating away the gains. But I also read that there are ways to stream in chunks/groups with pipes, so maybe there is a balance point, at which running this in parallel starts to work out.