### PR TITLE
Server api update

### DIFF
--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -2,12 +2,11 @@
 
 import           Poseidon.GenotypeData       (GenotypeDataSpec (..))
 import           Poseidon.Janno              (JannoList (..), JannoRow (..))
-import           Poseidon.Package            (PackageInfo (..),
-                                              PackageReadOptions (..),
+import           Poseidon.Package            (PackageReadOptions (..),
                                               PoseidonPackage (..),
                                               defaultPackageReadOptions,
                                               readPoseidonPackageCollection)
-import           Poseidon.SecondaryTypes     (IndividualInfo (..))
+import           Poseidon.SecondaryTypes     (IndividualInfo (..), PackageInfo (..))
 
 import           Codec.Archive.Zip           (Archive, addEntryToArchive,
                                               emptyArchive, fromArchive,

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -45,25 +45,6 @@ data CommandLineOptions = CommandLineOptions
     }
     deriving (Show)
 
-packageToPackageInfo :: PoseidonPackage -> PackageInfo
-packageToPackageInfo pac = PackageInfo {
-    pTitle = posPacTitle pac,
-    pVersion = posPacPackageVersion pac,
-    pDescription = posPacDescription pac,
-    pLastModified = posPacLastModified pac
-}
-
-logger :: String
-logger = rootLoggerName
-
-pacReadOpts :: PackageReadOptions
-pacReadOpts = defaultPackageReadOptions {
-      _readOptVerbose          = False
-    , _readOptStopOnDuplicates = True
-    , _readOptIgnoreChecksums  = False
-    , _readOptGenoCheck        = True
-    }
-
 main :: IO ()
 main = do
     h <- streamHandler stderr INFO
@@ -87,150 +68,48 @@ main = do
             Just (certFile, chainFiles, keyFile) -> scottyHTTPS port certFile chainFiles keyFile
     runScotty $ do
         middleware simpleCors
-        get "/packages" $
+
+        -- basic APIs for retreiving metadata
+        get "/janno_all" $
+            json (getAllPacJannoPairs allPackages)
+        get "/individuals_all" $
+            json (getAllIndividualInfo allPackages)
+        get "/groups_all" $
+            json (getAllGroupInfo allPackages)
+        get "/packages_all" $
             (json . map packageToPackageInfo) allPackages
-        get "/package_table" $
-            html . makeHTMLtable $ allPackages
-        get "/package_table_md.md" $
-            text . makeMDtable $ allPackages
+
+        -- API for retreiving package zip files
         when (not ignoreGenoFiles) . get "/zip_file/:package_name" $ do
             p_ <- param "package_name"
             let zipFN = lookup (unpack p_) zipDict
             case zipFN of
                 Just fn -> file fn
                 Nothing -> raise ("unknown package " <> p_)
-        get "/janno_all" $
-            json (getAllPacJannoPairs allPackages)
-        get "/individuals_all" $
-            json (getAllIndividualInfo allPackages)
+
+        -- API for version output
         get "/server_version" $
             text . pack . showVersion $ version
+
+        -- Ugly helper APIs for including package lists in docsify.
+        -- May not be needed when we switch to a "smarter" static site generator
+        get "/package_table" $
+            html . makeHTMLtable $ allPackages
+        get "/package_table_md.md" $
+            text . makeMDtable $ allPackages
+
+        -- Superseded by "/packages_all". I've kept this old API for backwards-compatibility only.
+        -- May get deprecated at some point
+        get "/packages" $
+            (json . map packageToPackageInfo) allPackages
+
         notFound $ raise "Unknown request"
   where
     p = OP.prefs OP.showHelpOnEmpty
 
-scottyHTTPS :: Int -> FilePath -> [FilePath] -> FilePath -> ScottyM () -> IO ()
-scottyHTTPS port cert chains key s = do
-    -- this is just the same output as with scotty, to make it consistent whether or not using https
-    infoM logger $ "Server now listening via HTTPS on " ++ show port
-    let tsls = case chains of
-            [] -> tlsSettings cert key
-            c  -> tlsSettingsChain cert c key
-    app <- scottyApp s
-    runTLS tsls (setPort port defaultSettings) app
+logger :: String
+logger = rootLoggerName
 
-scottyHTTP :: Int -> ScottyM () -> IO ()
-scottyHTTP port s = do
-    infoM logger $ "Server now listening via HTTP on " ++ show port
-    app <- scottyApp s
-    run port app
-
-
-checkZipFileOutdated :: PoseidonPackage -> FilePath -> Bool -> IO Bool
-checkZipFileOutdated pac fn ignoreGenoFiles = do
-    zipFileExists <- doesFileExist fn
-    if zipFileExists
-    then do
-        zipModTime <- getModificationTime fn
-        yamlOutdated <- checkOutdated zipModTime (posPacBaseDir pac </> "POSEIDON.yml")
-        bibOutdated <- case posPacBibFile pac of
-            Just fn_ -> checkOutdated zipModTime (posPacBaseDir pac </> fn_)
-            Nothing  -> return False
-        jannoOutdated <- case posPacJannoFile pac of
-            Just fn_ -> checkOutdated zipModTime (posPacBaseDir pac </> fn_)
-            Nothing  -> return False
-        readmeOutdated <- case posPacReadmeFile pac of
-            Just fn_ -> checkOutdated zipModTime (posPacBaseDir pac </> fn_)
-            Nothing -> return False
-        changelogOutdated <- case posPacChangelogFile pac of
-            Just fn_ -> checkOutdated zipModTime (posPacBaseDir pac </> fn_)
-            Nothing -> return False
-        let gd = posPacGenotypeData pac
-        genoOutdated <- if ignoreGenoFiles then return False else checkOutdated zipModTime (posPacBaseDir pac </> genoFile gd)
-        snpOutdated <- if ignoreGenoFiles then return False else checkOutdated zipModTime (posPacBaseDir pac </> snpFile gd)
-        indOutdated <- if ignoreGenoFiles then return False else checkOutdated zipModTime (posPacBaseDir pac </> indFile gd)
-        return $ or [yamlOutdated, bibOutdated, jannoOutdated, readmeOutdated, changelogOutdated, genoOutdated, snpOutdated, indOutdated]
-    else
-        return True
-  where
-    checkOutdated zipModTime fn_ = (> zipModTime) <$> getModificationTime fn_
-
-makeHTMLtable :: [PoseidonPackage] -> Text
-makeHTMLtable packages = "<table>" <> header <> body <> "</table>"
-  where
-    header :: Text
-    header = "<tr><th>Package Name</th><th>Description</th><th>Version</th><th>Last updated</th><th>Download</th></tr>"
-    body :: Text
-    body = intercalate "\n" $ do
-        pac <- packages
-        let (PackageInfo title version_ desc lastMod) = packageToPackageInfo pac
-        let link = "<a href=\"https://c107-224.cloud.gwdg.de/zip_file/" <> pack title <> "\">" <> pack title <> "</a>"
-        return $ "<tr><td>" <> pack title <> "</td><td>" <>
-            maybe "n/a" pack desc <> "</td><td>" <>
-            maybe "n/a" (pack . showVersion) version_ <> "</td><td>" <>
-            maybe "n/a" (pack . show) lastMod <> "</td><td>" <>
-            link <> "</td></tr>"
-
-makeMDtable :: [PoseidonPackage] -> Text
-makeMDtable packages = header <> "\n" <> body <> "\n"
-  where
-    header :: Text
-    header = "| Package Name | Description | Version | Last updated | Download |\n| --- | --- | --- | --- | --- |"
-    body :: Text
-    body = intercalate "\n" $ do
-        pac <- packages
-        let (PackageInfo title version_ desc lastMod) = packageToPackageInfo pac
-        let link = "[" <> pack title <> "](https://c107-224.cloud.gwdg.de/zip_file/" <> pack title <> ")"
-        return $ "| " <> pack title <> " | " <>
-            maybe "n/a" pack desc <> " | " <>
-            maybe "n/a" (pack . showVersion) version_ <> " | " <>
-            maybe "n/a" (pack . show) lastMod <> " | " <>
-            link <> " | "
-
-
-makeZipArchive :: PoseidonPackage -> Bool -> IO Archive
-makeZipArchive pac ignoreGenoFiles =
-    return emptyArchive >>= addYaml >>= addJanno >>= addBib >>= addReadme >>= addChangelog >>= addInd >>= addSnp >>= addGeno
-  where
-    addYaml = addFN "POSEIDON.yml" (posPacBaseDir pac)
-    addJanno = case posPacJannoFile pac of
-        Nothing -> return
-        Just fn -> addFN fn (posPacBaseDir pac)
-    addBib = case posPacBibFile pac of
-        Nothing -> return
-        Just fn -> addFN fn (posPacBaseDir pac)
-    addReadme = case posPacReadmeFile pac of
-        Nothing -> return
-        Just fn -> addFN fn (posPacBaseDir pac)
-    addChangelog = case posPacChangelogFile pac of
-        Nothing -> return
-        Just fn -> addFN fn (posPacBaseDir pac)
-    addInd = addFN (indFile . posPacGenotypeData $ pac) (posPacBaseDir pac)
-    addSnp = if ignoreGenoFiles
-             then return
-             else addFN (snpFile . posPacGenotypeData $ pac) (posPacBaseDir pac)
-    addGeno = if ignoreGenoFiles
-              then return
-              else addFN (genoFile . posPacGenotypeData $ pac) (posPacBaseDir pac)
-    addFN :: FilePath -> FilePath -> Archive -> IO Archive
-    addFN fn baseDir a = do
-        let fullFN = baseDir </> fn
-        raw <- B.readFile fullFN
-        modTime <- (round . utcTimeToPOSIXSeconds) <$> getModificationTime fullFN
-        let zipEntry = toEntry fn modTime raw
-        return (addEntryToArchive zipEntry a)
-
-getAllIndividualInfo :: [PoseidonPackage] -> [IndividualInfo]
-getAllIndividualInfo packages = do
-    pac <- packages
-    jannoRow <- posPacJanno pac
-    let name = jIndividualID jannoRow
-        group = head . getJannoList . jGroupName $ jannoRow
-        pacName = posPacTitle pac
-    return $ IndividualInfo name group pacName
-
-getAllPacJannoPairs :: [PoseidonPackage] -> [(String, [JannoRow])]
-getAllPacJannoPairs packages = [(posPacTitle pac, posPacJanno pac) | pac <- packages]
 
 optParserInfo :: OP.ParserInfo CommandLineOptions
 optParserInfo = OP.info (OP.helper <*> versionOption <*> optParser) (
@@ -279,3 +158,143 @@ parseChainFile = OP.strOption (OP.long "chainFile" <> OP.metavar "CHAINFILE" <>
 parseCertFile :: OP.Parser FilePath
 parseCertFile = OP.strOption (OP.long "certFile" <> OP.metavar "CERTFILE" <>
                               OP.help "The cert file of the TLS Certificate used for HTTPS")
+
+pacReadOpts :: PackageReadOptions
+pacReadOpts = defaultPackageReadOptions {
+      _readOptVerbose          = False
+    , _readOptStopOnDuplicates = True
+    , _readOptIgnoreChecksums  = False
+    , _readOptGenoCheck        = True
+    }
+
+checkZipFileOutdated :: PoseidonPackage -> FilePath -> Bool -> IO Bool
+checkZipFileOutdated pac fn ignoreGenoFiles = do
+    zipFileExists <- doesFileExist fn
+    if zipFileExists
+    then do
+        zipModTime <- getModificationTime fn
+        yamlOutdated <- checkOutdated zipModTime (posPacBaseDir pac </> "POSEIDON.yml")
+        bibOutdated <- case posPacBibFile pac of
+            Just fn_ -> checkOutdated zipModTime (posPacBaseDir pac </> fn_)
+            Nothing  -> return False
+        jannoOutdated <- case posPacJannoFile pac of
+            Just fn_ -> checkOutdated zipModTime (posPacBaseDir pac </> fn_)
+            Nothing  -> return False
+        readmeOutdated <- case posPacReadmeFile pac of
+            Just fn_ -> checkOutdated zipModTime (posPacBaseDir pac </> fn_)
+            Nothing -> return False
+        changelogOutdated <- case posPacChangelogFile pac of
+            Just fn_ -> checkOutdated zipModTime (posPacBaseDir pac </> fn_)
+            Nothing -> return False
+        let gd = posPacGenotypeData pac
+        genoOutdated <- if ignoreGenoFiles then return False else checkOutdated zipModTime (posPacBaseDir pac </> genoFile gd)
+        snpOutdated <- if ignoreGenoFiles then return False else checkOutdated zipModTime (posPacBaseDir pac </> snpFile gd)
+        indOutdated <- if ignoreGenoFiles then return False else checkOutdated zipModTime (posPacBaseDir pac </> indFile gd)
+        return $ or [yamlOutdated, bibOutdated, jannoOutdated, readmeOutdated, changelogOutdated, genoOutdated, snpOutdated, indOutdated]
+    else
+        return True
+  where
+    checkOutdated zipModTime fn_ = (> zipModTime) <$> getModificationTime fn_
+
+makeZipArchive :: PoseidonPackage -> Bool -> IO Archive
+makeZipArchive pac ignoreGenoFiles =
+    return emptyArchive >>= addYaml >>= addJanno >>= addBib >>= addReadme >>= addChangelog >>= addInd >>= addSnp >>= addGeno
+  where
+    addYaml = addFN "POSEIDON.yml" (posPacBaseDir pac)
+    addJanno = case posPacJannoFile pac of
+        Nothing -> return
+        Just fn -> addFN fn (posPacBaseDir pac)
+    addBib = case posPacBibFile pac of
+        Nothing -> return
+        Just fn -> addFN fn (posPacBaseDir pac)
+    addReadme = case posPacReadmeFile pac of
+        Nothing -> return
+        Just fn -> addFN fn (posPacBaseDir pac)
+    addChangelog = case posPacChangelogFile pac of
+        Nothing -> return
+        Just fn -> addFN fn (posPacBaseDir pac)
+    addInd = addFN (indFile . posPacGenotypeData $ pac) (posPacBaseDir pac)
+    addSnp = if ignoreGenoFiles
+             then return
+             else addFN (snpFile . posPacGenotypeData $ pac) (posPacBaseDir pac)
+    addGeno = if ignoreGenoFiles
+              then return
+              else addFN (genoFile . posPacGenotypeData $ pac) (posPacBaseDir pac)
+    addFN :: FilePath -> FilePath -> Archive -> IO Archive
+    addFN fn baseDir a = do
+        let fullFN = baseDir </> fn
+        raw <- B.readFile fullFN
+        modTime <- (round . utcTimeToPOSIXSeconds) <$> getModificationTime fullFN
+        let zipEntry = toEntry fn modTime raw
+        return (addEntryToArchive zipEntry a)
+
+scottyHTTPS :: Int -> FilePath -> [FilePath] -> FilePath -> ScottyM () -> IO ()
+scottyHTTPS port cert chains key s = do
+    -- this is just the same output as with scotty, to make it consistent whether or not using https
+    infoM logger $ "Server now listening via HTTPS on " ++ show port
+    let tsls = case chains of
+            [] -> tlsSettings cert key
+            c  -> tlsSettingsChain cert c key
+    app <- scottyApp s
+    runTLS tsls (setPort port defaultSettings) app
+
+scottyHTTP :: Int -> ScottyM () -> IO ()
+scottyHTTP port s = do
+    infoM logger $ "Server now listening via HTTP on " ++ show port
+    app <- scottyApp s
+    run port app
+
+makeHTMLtable :: [PoseidonPackage] -> Text
+makeHTMLtable packages = "<table>" <> header <> body <> "</table>"
+  where
+    header :: Text
+    header = "<tr><th>Package Name</th><th>Description</th><th>Version</th><th>Last updated</th><th>Download</th></tr>"
+    body :: Text
+    body = intercalate "\n" $ do
+        pac <- packages
+        let (PackageInfo title version_ desc lastMod) = packageToPackageInfo pac
+        let link = "<a href=\"https://c107-224.cloud.gwdg.de/zip_file/" <> pack title <> "\">" <> pack title <> "</a>"
+        return $ "<tr><td>" <> pack title <> "</td><td>" <>
+            maybe "n/a" pack desc <> "</td><td>" <>
+            maybe "n/a" (pack . showVersion) version_ <> "</td><td>" <>
+            maybe "n/a" (pack . show) lastMod <> "</td><td>" <>
+            link <> "</td></tr>"
+
+makeMDtable :: [PoseidonPackage] -> Text
+makeMDtable packages = header <> "\n" <> body <> "\n"
+  where
+    header :: Text
+    header = "| Package Name | Description | Version | Last updated | Download |\n| --- | --- | --- | --- | --- |"
+    body :: Text
+    body = intercalate "\n" $ do
+        pac <- packages
+        let (PackageInfo title version_ desc lastMod) = packageToPackageInfo pac
+        let link = "[" <> pack title <> "](https://c107-224.cloud.gwdg.de/zip_file/" <> pack title <> ")"
+        return $ "| " <> pack title <> " | " <>
+            maybe "n/a" pack desc <> " | " <>
+            maybe "n/a" (pack . showVersion) version_ <> " | " <>
+            maybe "n/a" (pack . show) lastMod <> " | " <>
+            link <> " | "
+
+getAllPacJannoPairs :: [PoseidonPackage] -> [(String, [JannoRow])]
+getAllPacJannoPairs packages = [(posPacTitle pac, posPacJanno pac) | pac <- packages]
+
+getAllIndividualInfo :: [PoseidonPackage] -> [IndividualInfo]
+getAllIndividualInfo packages = do
+    pac <- packages
+    jannoRow <- posPacJanno pac
+    let name = jIndividualID jannoRow
+        group = head . getJannoList . jGroupName $ jannoRow
+        pacName = posPacTitle pac
+    return $ IndividualInfo name group pacName
+
+getAllGroupInfo :: [PoseidonPackage] -> [GroupInfo]
+getAllGroupInfo packages = undefined
+
+packageToPackageInfo :: PoseidonPackage -> PackageInfo
+packageToPackageInfo pac = PackageInfo {
+    pTitle = posPacTitle pac,
+    pVersion = posPacPackageVersion pac,
+    pDescription = posPacDescription pac,
+    pLastModified = posPacLastModified pac
+}

--- a/src/Poseidon/CLI/Fetch.hs
+++ b/src/Poseidon/CLI/Fetch.hs
@@ -2,39 +2,39 @@
 
 module Poseidon.CLI.Fetch where
 
-import           Poseidon.EntitiesList  (EntitiesList, PoseidonEntity (..),
-                                         readEntitiesFromFile)
-import           Poseidon.MathHelpers   (roundTo, roundToStr)
-import           Poseidon.Package       (PackageInfo (..),
-                                         PackageReadOptions (..),
-                                         PoseidonPackage (..),
-                                         defaultPackageReadOptions,
-                                         readPoseidonPackageCollection)
-import           Poseidon.Utils         (PoseidonException (..))
+import           Poseidon.EntitiesList   (EntitiesList, PoseidonEntity (..),
+                                          readEntitiesFromFile)
+import           Poseidon.MathHelpers    (roundTo, roundToStr)
+import           Poseidon.Package        (PackageReadOptions (..),
+                                          PoseidonPackage (..),
+                                          defaultPackageReadOptions,
+                                          readPoseidonPackageCollection)
+import           Poseidon.SecondaryTypes (PackageInfo (..))
+import           Poseidon.Utils          (PoseidonException (..))
 
-import           Codec.Archive.Zip      (ZipOption (..),
-                                         extractFilesFromArchive, toArchive)
-import           Conduit                (ResourceT, await, runResourceT,
-                                         sinkFile, yield)
-import           Control.Exception      (throwIO)
-import           Control.Monad          (unless, when)
-import           Control.Monad.IO.Class (liftIO)
-import           Data.Aeson             (eitherDecode')
-import qualified Data.ByteString        as B
-import           Data.ByteString.Char8  as B8 (unpack)
-import qualified Data.ByteString.Lazy   as LB
-import           Data.Conduit           (ConduitT, sealConduitT, ($$+-), (.|))
-import           Data.List              (nub)
-import           Data.Version           (Version, showVersion)
-import           Network.HTTP.Conduit   (http, newManager, parseRequest,
-                                         responseBody, responseHeaders,
-                                         simpleHttp, tlsManagerSettings)
-import           Network.HTTP.Types     (hContentLength)
-import           System.Console.ANSI    (hClearLine, hSetCursorColumn)
-import           System.Directory       (createDirectoryIfMissing,
-                                         removeDirectory, removeFile)
-import           System.FilePath        ((</>))
-import           System.IO              (hFlush, hPutStr, hPutStrLn, stderr)
+import           Codec.Archive.Zip       (ZipOption (..),
+                                          extractFilesFromArchive, toArchive)
+import           Conduit                 (ResourceT, await, runResourceT,
+                                          sinkFile, yield)
+import           Control.Exception       (throwIO)
+import           Control.Monad           (unless, when)
+import           Control.Monad.IO.Class  (liftIO)
+import           Data.Aeson              (eitherDecode')
+import qualified Data.ByteString         as B
+import           Data.ByteString.Char8   as B8 (unpack)
+import qualified Data.ByteString.Lazy    as LB
+import           Data.Conduit            (ConduitT, sealConduitT, ($$+-), (.|))
+import           Data.List               (nub)
+import           Data.Version            (Version, showVersion)
+import           Network.HTTP.Conduit    (http, newManager, parseRequest,
+                                          responseBody, responseHeaders,
+                                          simpleHttp, tlsManagerSettings)
+import           Network.HTTP.Types      (hContentLength)
+import           System.Console.ANSI     (hClearLine, hSetCursorColumn)
+import           System.Directory        (createDirectoryIfMissing,
+                                          removeDirectory, removeFile)
+import           System.FilePath         ((</>))
+import           System.IO               (hFlush, hPutStr, hPutStrLn, stderr)
 
 data FetchOptions = FetchOptions
     { _jaBaseDirs      :: [FilePath]

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Poseidon.Package (
-    PackageInfo (..),
     PoseidonYamlStruct (..),
     PoseidonPackage(..),
     PoseidonException(..),
@@ -65,30 +64,6 @@ import           System.Directory           (doesDirectoryExist, doesFileExist,
 import           System.FilePath            (takeDirectory, takeFileName, (</>))
 import           System.IO                  (hFlush, hPrint, hPutStr, hPutStrLn,
                                              stderr)
-
--- | Minimal package representation on Poseidon servers
-data PackageInfo = PackageInfo
-    { pTitle        :: String
-    , pVersion      :: Maybe Version
-    , pDescription  :: Maybe String
-    , pLastModified :: Maybe Day
-    }
-    deriving (Show)
-
-instance ToJSON PackageInfo where
-    toJSON x = object [
-        "title"        .= pTitle x,
-        "version"      .= pVersion x,
-        "description"  .= pDescription x,
-        "lastModified" .= pLastModified x
-        ]
-
-instance FromJSON PackageInfo where
-    parseJSON = withObject "PackageInfo" $ \v -> PackageInfo
-        <$> v .:   "title"
-        <*> v .:   "version"
-        <*> v .:?  "description"
-        <*> v .:   "lastModified"
 
 -- | Internal structure for YAML loading only
 data PoseidonYamlStruct = PoseidonYamlStruct

--- a/src/Poseidon/SecondaryTypes.hs
+++ b/src/Poseidon/SecondaryTypes.hs
@@ -5,17 +5,21 @@ module Poseidon.SecondaryTypes (
     ContributorSpec (..),
     contributorSpecParser,
     IndividualInfo (..),
-    VersionComponent (..)
+    VersionComponent (..),
+    PackageInfo(..)
 ) where
 
-import           Data.Aeson             (FromJSON, ToJSON, object,
-                                        parseJSON, toJSON, withObject,
-                                        (.:), (.=))
-import           Data.Version           (Version (..), makeVersion)
-import qualified Text.Parsec            as P
-import qualified Text.Parsec.String     as P
+import           Data.Aeson         (FromJSON, ToJSON, object, parseJSON,
+                                     toJSON, withObject, (.:), (.=), (.:?))
+import           Data.Time          (Day)
+import           Data.Version       (Version (..), makeVersion)
+import qualified Text.Parsec        as P
+import qualified Text.Parsec.String as P
 
-data VersionComponent = Major | Minor | Patch
+
+data VersionComponent = Major
+    | Minor
+    | Patch
     deriving Show
 
 data IndividualInfo = IndividualInfo
@@ -35,6 +39,31 @@ instance FromJSON IndividualInfo where
         <$> v .:   "name"
         <*> v .:   "group"
         <*> v .:  "pacName"
+
+-- | Minimal package representation on Poseidon servers
+data PackageInfo = PackageInfo
+    { pTitle        :: String
+    , pVersion      :: Maybe Version
+    , pDescription  :: Maybe String
+    , pLastModified :: Maybe Day
+    }
+    deriving (Show)
+
+instance ToJSON PackageInfo where
+    toJSON x = object [
+        "title"        .= pTitle x,
+        "version"      .= pVersion x,
+        "description"  .= pDescription x,
+        "lastModified" .= pLastModified x
+        ]
+
+instance FromJSON PackageInfo where
+    parseJSON = withObject "PackageInfo" $ \v -> PackageInfo
+        <$> v .:   "title"
+        <*> v .:   "version"
+        <*> v .:?  "description"
+        <*> v .:   "lastModified"
+
 
 poseidonVersionParser :: P.Parser Version
 poseidonVersionParser = do

--- a/src/Poseidon/SecondaryTypes.hs
+++ b/src/Poseidon/SecondaryTypes.hs
@@ -5,12 +5,13 @@ module Poseidon.SecondaryTypes (
     ContributorSpec (..),
     contributorSpecParser,
     IndividualInfo (..),
+    GroupInfo(..),
     VersionComponent (..),
     PackageInfo(..)
 ) where
 
 import           Data.Aeson         (FromJSON, ToJSON, object, parseJSON,
-                                     toJSON, withObject, (.:), (.=), (.:?))
+                                     toJSON, withObject, (.:), (.:?), (.=))
 import           Data.Time          (Day)
 import           Data.Version       (Version (..), makeVersion)
 import qualified Text.Parsec        as P
@@ -24,14 +25,14 @@ data VersionComponent = Major
 
 data IndividualInfo = IndividualInfo
     { indInfoName    :: String
-    , indInfoGroup   :: String
+    , indInfoGroups   :: [String]
     , indInfoPacName :: String
     }
 
 instance ToJSON IndividualInfo where
     toJSON x = object [
-        "name" .= indInfoName x,
-        "group" .= indInfoGroup x,
+        "name"    .= indInfoName x,
+        "group"   .= indInfoGroups x,
         "pacName" .= indInfoPacName x]
 
 instance FromJSON IndividualInfo where
@@ -42,19 +43,21 @@ instance FromJSON IndividualInfo where
 
 -- | Minimal package representation on Poseidon servers
 data PackageInfo = PackageInfo
-    { pTitle        :: String
-    , pVersion      :: Maybe Version
-    , pDescription  :: Maybe String
-    , pLastModified :: Maybe Day
+    { pTitle         :: String
+    , pVersion       :: Maybe Version
+    , pDescription   :: Maybe String
+    , pLastModified  :: Maybe Day
+    , pNrIndividuals :: Int
     }
     deriving (Show)
 
 instance ToJSON PackageInfo where
     toJSON x = object [
-        "title"        .= pTitle x,
-        "version"      .= pVersion x,
-        "description"  .= pDescription x,
-        "lastModified" .= pLastModified x
+        "title"         .= pTitle x,
+        "version"       .= pVersion x,
+        "description"   .= pDescription x,
+        "lastModified"  .= pLastModified x,
+        "nrIndividuals" .= pNrIndividuals x
         ]
 
 instance FromJSON PackageInfo where
@@ -63,7 +66,25 @@ instance FromJSON PackageInfo where
         <*> v .:   "version"
         <*> v .:?  "description"
         <*> v .:   "lastModified"
+        <*> v .:   "nrIndividuals"
 
+data GroupInfo = GroupInfo
+    { gName          :: String
+    , gPackageNames  :: [String]
+    , gNrIndividuals :: Int
+    }
+
+instance ToJSON GroupInfo where
+    toJSON x = object [
+        "name"          .= gName x,
+        "packages"      .= gPackageNames x,
+        "nrIndividuals" .= gNrIndividuals x]
+
+instance FromJSON GroupInfo where
+    parseJSON = withObject "GroupInfo" $ \v -> GroupInfo
+        <$> v .: "name"
+        <*> v .: "packages"
+        <*> v .: "nrIndividuals"
 
 poseidonVersionParser :: P.Parser Version
 poseidonVersionParser = do

--- a/test/Poseidon/GoldenTestsRunCommands.hs
+++ b/test/Poseidon/GoldenTestsRunCommands.hs
@@ -313,13 +313,18 @@ testPipelineForge testDir checkFilePath = do
         , "ForgePac2" </> "ForgePac2.janno"
         ]
 
+ -- Note: We here use our test server (no SSL and different port). The reason is that 
+ -- sometimes we would like to implement new features that affect the communication
+ -- between server and client, and we need tests succeeding before Pull Requests are merged, so
+ -- we adopt the policy to run experimental builds on the test server in order to test features
+ -- before running them on the main server.
 testPipelineFetch :: FilePath -> FilePath -> IO ()
 testPipelineFetch testDir checkFilePath = do
     let fetchOpts1 = FetchOptions { 
           _jaBaseDirs       = [testDir]
         , _entityList       = [Pac "2019_Nikitin_LBK"]
         , _entityFiles      = []
-        , _remoteURL        = "https://c107-224.cloud.gwdg.de"
+        , _remoteURL        = "http://c107-224.cloud.gwdg.de:3000"
         , _upgrade          = True
         , _downloadAllPacs  = False 
         }


### PR DESCRIPTION
In this branch, I've made some updates to the server APIs. In particular I have 

* updated the name from `/packages` to `/packages_all` to make more consistent with `/individuals_all` and `/janno_all`. Of course, I've kept the old API around for backwards compatibility
* added a new API `/groups_all`
* made the API `/individuals_all` korrekt in terms of groups shown (now a list, not just the first)
* restructured the code a bit to be clearer

This is in preparation to updates in `list` and `fetch`. I've realised that the current approach in `list` downloads the entire Janne-data every time, which is nearly 7 Megabytes. In contrast, a simple package list is only 35k, and an individual list only 100K. So I'd like to make `list` cleverer and using the new APIs to speed things up.