### PR TITLE
Better errors janno parsing

### DIFF
--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -66,8 +66,8 @@ instance Csv.FromField JannoSex where
         | x == "F" = pure (JannoSex Female)
         | x == "M" = pure (JannoSex Male)
         | x == "U" = pure (JannoSex Unknown)
-        | otherwise = empty
-
+        | otherwise = fail $ "Sex " ++ show x ++ " not in [F, M, U]"
+ 
 instance Csv.ToField JannoSex where
     toField (JannoSex Female)  = "F"
     toField (JannoSex Male)    = "M"
@@ -106,7 +106,7 @@ instance Csv.FromField JannoDateType where
         | x == "C14" = pure C14
         | x == "contextual" = pure Contextual
         | x == "modern" = pure Modern
-        | otherwise = empty
+        | otherwise = fail $ "Date_Type " ++ show x ++ " not in [C14, contextual, modern]"
 
 instance Csv.ToField JannoDateType where
     toField C14        = "C14"
@@ -136,7 +136,7 @@ instance Csv.FromField JannoDataType where
         | x == "1240K" = pure A1240K
         | x == "OtherCapture" = pure OtherCapture
         | x == "ReferenceGenome" = pure ReferenceGenome
-        | otherwise = empty
+        | otherwise = fail $ "Data_Type " ++ show x ++ "  not in [Shotgun, 1240K, OtherCapture, ReferenceGenome]"
 
 instance Csv.ToField JannoDataType where
     toField Shotgun         = "Shotgun"
@@ -164,7 +164,7 @@ instance Csv.FromField JannoGenotypePloidy where
     parseField x
         | x == "diploid" = pure Diploid
         | x == "haploid" = pure Haploid
-        | otherwise = empty
+        | otherwise = fail $ "Genotype_Ploidy " ++ show x ++ " not in [diploid, haploid]"
 
 instance Csv.ToField JannoGenotypePloidy where
     toField Diploid = "diploid"
@@ -192,7 +192,7 @@ instance Csv.FromField JannoUDG where
         | x == "half" = pure Half
         | x == "plus" = pure Plus
         | x == "mixed" = pure Mixed
-        | otherwise = empty
+        | otherwise = fail $ "UDG " ++ show x ++ " not in [minus, half, plus, mixed]"
 
 instance Csv.ToField JannoUDG where
     toField Minus = "minus"
@@ -217,7 +217,7 @@ instance Csv.FromField JannoLibraryBuilt where
         | x == "ds" = pure DS
         | x == "ss" = pure SS
         | x == "other" = pure Other
-        | otherwise = empty
+        | otherwise = fail $ "Library_Built " ++ show x ++ " not in [ds, ss, other]"
 
 instance Csv.ToField JannoLibraryBuilt where
     toField DS    = "ds"
@@ -248,7 +248,7 @@ instance Csv.FromField Latitude where
     parseField x = do
         val <- Csv.parseField x
         if val < -90 || val > 90
-        then empty
+        then fail $ "Latitude " ++ show x ++ " not between -90 and 90"
         else pure (Latitude val)
 
 instance Csv.ToField Latitude where
@@ -271,7 +271,7 @@ instance Csv.FromField Longitude where
     parseField x = do
         val <- Csv.parseField x
         if val < -180 || val > 180
-        then empty
+        then fail $ "Longitude " ++ show x ++ " not between -180 and 180"
         else pure (Longitude val)
 
 instance Csv.ToField Longitude where
@@ -294,7 +294,7 @@ instance Csv.FromField Percent where
     parseField x = do
         val <- Csv.parseField x
         if val < 0  || val > 100
-        then empty
+        then fail $ "Percent value " ++ show x ++ " not between 0 and 100"
         else pure (Percent val)
 
 instance Csv.ToField Percent where
@@ -316,7 +316,7 @@ instance Csv.FromField JURI where
     parseField x = do
         val <- Csv.parseField x
         if not $ isURI val
-        then empty 
+        then fail $ "URI " ++ show x ++ " not well structured"
         else pure $ JURI val
 
 instance Csv.ToField JURI where


### PR DESCRIPTION
I briefly looked into better parsing for .janno files and saw a trivial but significant option to improve the error messages.

With this patch, the issue where @TCLamnidis got stuck recently gets reported as:

```
Can't read sample in ./2010_RasmussenNature.janno in line 2: 
parse error (Failed reading: conversion error: Data_Type "1240k" not in [Shotgun, 1240K, OtherCapture, ReferenceGenome])
```

Much better than

```
Can't read sample in /mnt/archgen/users/lamnidis/2020_BarqueraCurrentBiology/2020_BarqueraCurrentBiology.janno in line 4: 
parse error (Failed reading: conversion error: empty) at ""
```

I think there is even more room for improvement without rewriting the whole parser. Cassava uses Attoparsec and should actually report the unconsumed leftovers. See [here](https://hackage.haskell.org/package/cassava-0.5.2.0/docs/src/Data.Csv.Encoding.html#decodeWithP'):

```haskell
decodeWithP' p s =
    case AL.parse p s of
      AL.Done _ v     -> Right v
      AL.Fail left _ msg -> Left errMsg
        where
          errMsg = "parse error (" ++ msg ++ ") at " ++
                   (if BL8.length left > 100
                    then (take 100 $ BL8.unpack left) ++ " (truncated)"
                    else show (BL8.unpack left))
```

But somehow this does not work for us and I failed to figure out why. So for the time being I resorted to removing the useless trailing `at ""`. But maybe you immediately see the issue here @stschiff.
