### PR TITLE
changed CLI interface for forgeString

### DIFF
--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -281,7 +281,7 @@ parseForce = OP.switch (
     )
 
 parseForgeEntitySpec :: OP.Parser (Either SignedEntitiesList FilePath)
-parseForgeEntitySpec = (Left <$> parseForgeEntitiesDirect) <|> (Right <$> parseForgeEntitiesFromFile)
+parseForgeEntitySpec = (Right <$> parseForgeEntitiesFromFile) <|> (Left <$> parseForgeEntitiesDirect)
 
 parseIgnorePoseidonVersion :: OP.Parser Bool
 parseIgnorePoseidonVersion = OP.switch (
@@ -292,7 +292,7 @@ parseIgnorePoseidonVersion = OP.switch (
     )
 
 parseForgeEntitiesDirect :: OP.Parser SignedEntitiesList
-parseForgeEntitiesDirect = concat <$> OP.some (OP.option (OP.eitherReader readSignedEntities) (OP.long "forgeString" <>
+parseForgeEntitiesDirect = OP.option (OP.eitherReader readSignedEntities) (OP.long "forgeString" <>
     OP.short 'f' <>
     OP.help "List of packages, groups or individual samples to be combined in the output package. \
         \Packages follow the syntax *package_title*, populations/groups are simply group_id and individuals \
@@ -303,7 +303,7 @@ parseForgeEntitiesDirect = concat <$> OP.some (OP.option (OP.eitherReader readSi
         \forge will apply excludes and includes in order. If the first entity is negative, then forge \
         \will assume you want to merge all individuals in the \
         \packages found in the baseDirs (except the ones explicitly excluded) before the exclude entities are applied. \
-        \An empty forgeString will therefore merge all available individuals."))
+        \An empty forgeString will therefore merge all available individuals." <> OP.value [])
   where
     readSignedEntities s = case readEntitiesFromString s of
         Left e -> Left (show e)


### PR DESCRIPTION
very simple change that 
1) allows `forge` to work without either a forgeString or a forgeFile, interpreting as simply as `-f ""`, so an empty list of forge entities triggering a total merge.
2) removes the possibility to give multiple forge-strings, which I don't think makes much sense given that we already parse comma-separated values. 