### PR TITLE
switch to GHC 8.10.7

### DIFF
--- a/.github/workflows/Dockerfile.centos
+++ b/.github/workflows/Dockerfile.centos
@@ -4,9 +4,9 @@ RUN yum -y update
 RUN yum -y install zlib-devel wget ncurses-devel ncurses-compat-libs make gcc
 
 # Install GHC since stack's local install has issues
-RUN wget https://downloads.haskell.org/~ghc/8.10.3/ghc-8.10.3-x86_64-centos7-linux.tar.xz
-RUN tar xvf ghc-8.10.3-x86_64-centos7-linux.tar.xz
-RUN cd ghc-8.10.3; ./configure; make install
+RUN wget https://downloads.haskell.org/~ghc/8.10.7/ghc-8.10.7-x86_64-centos7-linux.tar.xz
+RUN tar xvf ghc-8.10.7-x86_64-centos7-linux.tar.xz
+RUN cd ghc-8.10.7; ./configure; make install
 
 # install stack
 RUN curl -sSL https://get.haskellstack.org/ | sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         stack: ["latest"]
-        ghc: ["8.10.3"]
+        ghc: ["8.10.7"]
 
     steps:
     # setup and loading cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, macOS-latest, windows-latest]
         cabal: ["3.2"]
-        ghc: ["8.10.3"]
+        ghc: ["8.10.7"]
 
     steps:
       - name: Check out code

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages: ./*.cabal
-with-compiler: ghc-8.10.3
+with-compiler: ghc-8.10.7
 
 package pandoc-citeproc
     flags: +embed_data_files

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.1
+resolver: lts-18.28
 
 packages:
 - .
@@ -8,3 +8,5 @@ extra-deps:
 - sequence-formats-1.6.1
 - yaml-pretty-extras-0.0.2.2
 - pipes-ordered-zip-1.2.1
+- co-log-0.4.0.1@sha256:3d4c17f37693c80d1aa2c41669bc3438fac3e89dc5f479e57d79bc3ddc4dfcc5,5087
+- ansi-terminal-0.10.3@sha256:e2fbcef5f980dc234c7ad8e2fa433b0e8109132c9e643bc40ea5608cd5697797,3226

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -39,9 +39,23 @@ packages:
       sha256: 099f71b0cecdaee9feae0bbf165491c57082ee259f7b5a593f96cfbccd36ba49
   original:
     hackage: pipes-ordered-zip-1.2.1
+- completed:
+    hackage: co-log-0.4.0.1@sha256:3d4c17f37693c80d1aa2c41669bc3438fac3e89dc5f479e57d79bc3ddc4dfcc5,5087
+    pantry-tree:
+      size: 1126
+      sha256: e73165ff8f744709428e2e87984c9d60ca1cec43d8455c413181c7c466e7497c
+  original:
+    hackage: co-log-0.4.0.1@sha256:3d4c17f37693c80d1aa2c41669bc3438fac3e89dc5f479e57d79bc3ddc4dfcc5,5087
+- completed:
+    hackage: ansi-terminal-0.10.3@sha256:e2fbcef5f980dc234c7ad8e2fa433b0e8109132c9e643bc40ea5608cd5697797,3226
+    pantry-tree:
+      size: 1461
+      sha256: 02f05d52be3ffcf36c78876629cbab80b63420672685371aea4fd10e1c4aabb6
+  original:
+    hackage: ansi-terminal-0.10.3@sha256:e2fbcef5f980dc234c7ad8e2fa433b0e8109132c9e643bc40ea5608cd5697797,3226
 snapshots:
 - completed:
-    size: 563098
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/1.yaml
-    sha256: 395775c03e66a4286f134d50346b0b6f1432131cf542886252984b4cfa5fef69
-  original: lts-17.1
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+  original: lts-18.28


### PR DESCRIPTION
 8.10.7 is only 9 months younger than 8.10.3, but it allows us to use the latest HLS version. There would be one younger stackage LTS release ([LTS 19.12 for ghc-9.0.2](https://www.stackage.org/lts-19.12)), but that is only 3 days old and may be unreliable. Also: `table-layout` does not work with GHC 9 yet.