### PR TITLE
properly parse base directories and genotype source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/_build/
 .stack-work/
+dist-newstyle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- V 1.1.0.0: Removed the short options (-r + -g + -s + -i) for the direct genotype data input. Also improved the trident input package and genotype data parsing by making pointless no-input situations impossible.
 - V 1.0.1.1: Output directories in fetch and genoconvert are now created if they don't exist.
 - V 1.0.1.0: Allowing flexible input of entity lists in fetch and forge.
 - V 1.0.0.2: Switched to GHC 8.10.7 and Stackage lts-18.28

--- a/CHANGELOGRELEASE.md
+++ b/CHANGELOGRELEASE.md
@@ -1,3 +1,13 @@
+### V 1.1.0.0
+
+This release summarises a number of smaller bugfixes and interface changes, but also introduces one minor breaking interface change, which makes it necessary to iterate the second major version number component.
+
+- *V 1.0.0.1* fixed a memory leak in `trident genoconvert`.
+- *V 1.0.0.2* brought the switch to a new compiler and dependency network version (GHC 8.10.7 and Stackage lts-18.28). This should not have any noticeable consequences for trident.
+- *V 1.0.1.0* reintroduced a feature lost in *V 0.27.0*: You can now again list multiple `-f/--forgeString`s and `--forgeFile`s in `trident forge` to structure your input. `trident fetch` now also supports multiple `-f/--fetchString`s and `--fetchFile`s.
+- *V 1.0.1.1* allowed `fetch` and `genoconvert` to create missing output directories automatically.
+- *V 1.1.0.0* is a breaking change, because it deprecates the short genotype data input options (`-r` + `-g` + `-s` + `-i`) in `init`, `forge` and `genoconvert`. It also improved the input of package and genotype data in `forge` and `genoconvert` by making pointless no-input situations impossible.
+
 ### V 1.0.0.0
 
 With this release we change to [PVP versioning](https://pvp.haskell.org). It introduces logging with the [co-log](https://hackage.haskell.org/package/co-log) library.

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -1,5 +1,5 @@
 name:                poseidon-hs
-version:             1.0.1.1
+version:             1.1.0.0
 synopsis:            A package with tools for working with Poseidon Genotype Data
 description:         The tools in this package read and analyse Poseidon-formatted genotype databases, a modular system for storing genotype data from thousands of individuals.
 license:             MIT

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -445,7 +445,8 @@ parseInGenoSep = (,,,) <$> parseInGenotypeFormat <*> parseInGenoFile <*> parseIn
 parseInGenotypeFormat :: OP.Parser GenotypeFormatSpec
 parseInGenotypeFormat = OP.option (OP.eitherReader readGenotypeFormat) (
     OP.long "inFormat" <>
-    OP.help "the format of the input genotype data: EIGENSTRAT or PLINK")
+    OP.help "the format of the input genotype data: EIGENSTRAT or PLINK\
+            \ (only necessary for data input with --genoFile + --snpFile + --indFile)")
   where
     readGenotypeFormat :: String -> Either String GenotypeFormatSpec
     readGenotypeFormat s = case s of

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -444,7 +444,7 @@ parseInGenoSep = (,,,) <$> parseInGenotypeFormat <*> parseInGenoFile <*> parseIn
 
 parseInGenotypeFormat :: OP.Parser GenotypeFormatSpec
 parseInGenotypeFormat = OP.option (OP.eitherReader readGenotypeFormat) (
-    OP.short 'r' <> OP.long "inFormat" <>
+    OP.long "inFormat" <>
     OP.help "the format of the input genotype data: EIGENSTRAT or PLINK")
   where
     readGenotypeFormat :: String -> Either String GenotypeFormatSpec
@@ -455,17 +455,17 @@ parseInGenotypeFormat = OP.option (OP.eitherReader readGenotypeFormat) (
 
 parseInGenoFile :: OP.Parser FilePath
 parseInGenoFile = OP.strOption (
-    OP.short 'g' <> OP.long "genoFile" <>
+    OP.long "genoFile" <>
     OP.help "the input geno file path")
 
 parseInSnpFile :: OP.Parser FilePath
 parseInSnpFile = OP.strOption (
-    OP.short 's' <> OP.long "snpFile" <>
+    OP.long "snpFile" <>
     OP.help "the input snp file path")
 
 parseInIndFile :: OP.Parser FilePath
 parseInIndFile = OP.strOption (
-    OP.short 'i' <> OP.long "indFile" <>
+    OP.long "indFile" <>
     OP.help "the input ind file path")
 
 parseGenotypeSNPSet :: OP.Parser (Maybe SNPSetSpec)

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import           Paths_poseidon_hs      (version)
-import           Poseidon.GenotypeData  (GenotypeFormatSpec (..), SNPSetSpec(..))
+import           Poseidon.GenotypeData  (GenotypeFormatSpec (..), SNPSetSpec(..), 
+                                         GenoDataSource (..))
 import           Poseidon.CLI.Init      (InitOptions (..), runInit)
 import           Poseidon.CLI.List      (ListEntity (..), ListOptions (..),
                                         runList, RepoLocationSpec(..))
@@ -198,8 +199,7 @@ fetchOptParser = FetchOptions <$> parseBasePaths
                               <*> parseDownloadAll
 
 forgeOptParser :: OP.Parser ForgeOptions
-forgeOptParser = ForgeOptions <$> parseBasePaths
-                              <*> parseInGenotypeDatasets
+forgeOptParser = ForgeOptions <$> parseGenoDataSources
                               <*> parseForgeEntitySpec
                               <*> parseMaybeSnpFile
                               <*> parseIntersect
@@ -212,8 +212,7 @@ forgeOptParser = ForgeOptions <$> parseBasePaths
                               <*> parseNoExtract
 
 genoconvertOptParser :: OP.Parser GenoconvertOptions
-genoconvertOptParser = GenoconvertOptions <$> parseBasePaths
-                                          <*> parseInGenotypeDatasets
+genoconvertOptParser = GenoconvertOptions <$> parseGenoDataSources
                                           <*> parseOutGenotypeFormat False
                                           <*> parseOutOnlyGeno
                                           <*> parseMaybeOutPackagePath
@@ -376,15 +375,6 @@ parseIntersect = OP.switch (OP.long "intersect" <>
         \defined as missing in those packages which do not have a SNP that is present in another package. \
         \With this option set, the forged dataset will typically have fewer SNPs, but less missingness.")
 
-parseRepoLocation :: OP.Parser RepoLocationSpec
-parseRepoLocation = (RepoLocal <$> parseBasePaths) <|> (parseRemoteDummy *> (RepoRemote <$> parseRemoteURL))
-
-parseBasePaths :: OP.Parser [FilePath]
-parseBasePaths = OP.many (OP.strOption (OP.long "baseDir" <>
-    OP.short 'd' <>
-    OP.metavar "DIR" <>
-    OP.help "a base directory to search for Poseidon Packages (could be a Poseidon repository)"))
-
 parseRemoteDummy :: OP.Parser ()
 parseRemoteDummy = OP.flag' () (OP.long "remote" <> OP.help "list packages from a remote server instead the local file system")
 
@@ -405,8 +395,23 @@ parseOutGenotypeFormat withDefault =
         "PLINK"      -> Right GenotypeFormatPlink
         _            -> Left "must be EIGENSTRAT or PLINK"
 
-parseInGenotypeDatasets :: OP.Parser [GenotypeDataSpec]
-parseInGenotypeDatasets = OP.many parseInGenotypeDataset
+parseGenoDataSources :: OP.Parser [GenoDataSource]
+parseGenoDataSources = OP.some parseGenoDataSource
+
+parseGenoDataSource :: OP.Parser GenoDataSource
+parseGenoDataSource = (PacBaseDir <$> parseBasePath) <|> (GenoDirect <$> parseInGenotypeDataset)
+
+parseRepoLocation :: OP.Parser RepoLocationSpec
+parseRepoLocation = (RepoLocal <$> parseBasePaths) <|> (parseRemoteDummy *> (RepoRemote <$> parseRemoteURL))
+
+parseBasePaths :: OP.Parser [FilePath]
+parseBasePaths = OP.some parseBasePath
+
+parseBasePath :: OP.Parser FilePath
+parseBasePath = OP.strOption (OP.long "baseDir" <>
+    OP.short 'd' <>
+    OP.metavar "DIR" <>
+    OP.help "a base directory to search for Poseidon Packages (could be a Poseidon repository)")
 
 parseInGenotypeDataset :: OP.Parser GenotypeDataSpec
 parseInGenotypeDataset = createGeno <$> (parseInGenoOne <|> parseInGenoSep) <*> parseGenotypeSNPSet

--- a/src/Poseidon/CLI/Genoconvert.hs
+++ b/src/Poseidon/CLI/Genoconvert.hs
@@ -5,7 +5,7 @@ module Poseidon.CLI.Genoconvert where
 import           Poseidon.GenotypeData      (GenotypeDataSpec (..),
                                              GenotypeFormatSpec (..),
                                              loadGenotypeData,
-                                             printSNPCopyProgress)
+                                             printSNPCopyProgress, GenoDataSource (..))
 import           Poseidon.Package           (readPoseidonPackageCollection,
                                              PoseidonPackage (..),
                                              writePoseidonPackage,
@@ -28,8 +28,7 @@ import           System.FilePath            ((<.>), (</>))
 
 -- | A datatype representing command line options for the validate command
 data GenoconvertOptions = GenoconvertOptions
-    { _genoconvertBaseDirs     :: [FilePath]
-    , _genoconvertInGenos      :: [GenotypeDataSpec]
+    { _genoconvertGenoSources  :: [GenoDataSource]
     , _genoConvertOutFormat    :: GenotypeFormatSpec
     , _genoConvertOutOnlyGeno  :: Bool
     , _genoMaybeOutPackagePath :: Maybe FilePath
@@ -46,10 +45,10 @@ pacReadOpts = defaultPackageReadOptions {
     }
 
 runGenoconvert :: GenoconvertOptions -> PoseidonLogIO ()
-runGenoconvert (GenoconvertOptions baseDirs inGenos outFormat onlyGeno outPath removeOld) = do
+runGenoconvert (GenoconvertOptions genoSources outFormat onlyGeno outPath removeOld) = do
     -- load packages
-    properPackages <- readPoseidonPackageCollection pacReadOpts baseDirs
-    pseudoPackages <- liftIO $ mapM makePseudoPackageFromGenotypeData inGenos
+    properPackages <- readPoseidonPackageCollection pacReadOpts $ [getPacBaseDirs x | x@PacBaseDir {} <- genoSources]
+    pseudoPackages <- liftIO $ mapM makePseudoPackageFromGenotypeData $ [getGenoDirect x | x@GenoDirect {} <- genoSources]
     logInfo $ pack $ "Unpackaged genotype data files loaded: " ++ show (length pseudoPackages)
     -- convert
     mapM_ (convertGenoTo outFormat onlyGeno outPath removeOld) properPackages

--- a/src/Poseidon/GenotypeData.hs
+++ b/src/Poseidon/GenotypeData.hs
@@ -26,6 +26,11 @@ import           System.Console.ANSI        (hClearLine, hSetCursorColumn)
 import           System.FilePath            ((</>))
 import           System.IO                  (hFlush, hPutStr, stderr)
 
+data GenoDataSource =
+      PacBaseDir {getPacBaseDirs :: FilePath}
+    | GenoDirect {getGenoDirect :: GenotypeDataSpec}
+    deriving Show
+
 -- | A datatype to specify genotype files
 data GenotypeDataSpec = GenotypeDataSpec
     { format         :: GenotypeFormatSpec

--- a/src/Poseidon/SecondaryTypes.hs
+++ b/src/Poseidon/SecondaryTypes.hs
@@ -18,7 +18,6 @@ import           Data.Version       (Version (..), makeVersion)
 import qualified Text.Parsec        as P
 import qualified Text.Parsec.String as P
 
-
 data VersionComponent = Major
     | Minor
     | Patch

--- a/test/Poseidon/GoldenTestsRunCommands.hs
+++ b/test/Poseidon/GoldenTestsRunCommands.hs
@@ -17,7 +17,7 @@ import           Poseidon.CLI.Survey            (SurveyOptions(..), runSurvey)
 import           Poseidon.CLI.Validate          (ValidateOptions(..), runValidate)
 import           Poseidon.GenotypeData          (GenotypeDataSpec (..),
                                                  GenotypeFormatSpec (..), 
-                                                 SNPSetSpec (..))
+                                                 SNPSetSpec (..), GenoDataSource (..))
 import           Poseidon.Package               (getChecksum)
 import           Poseidon.SecondaryTypes        (ContributorSpec (..),
                                                  VersionComponent (..))
@@ -222,8 +222,7 @@ testPipelineSurvey testDir checkFilePath = do
 testPipelineGenoconvert :: FilePath -> FilePath -> IO ()
 testPipelineGenoconvert testDir checkFilePath = do
     let genoconvertOpts1 = GenoconvertOptions {
-          _genoconvertBaseDirs = [testDir </> "Wang"]
-        , _genoconvertInGenos = []
+          _genoconvertGenoSources = [PacBaseDir $ testDir </> "Wang"]
         , _genoConvertOutFormat = GenotypeFormatEigenstrat
         , _genoConvertOutOnlyGeno = False
         , _genoMaybeOutPackagePath = Nothing
@@ -235,8 +234,7 @@ testPipelineGenoconvert testDir checkFilePath = do
         , "Wang" </> "Wang.ind"
         ]
     let genoconvertOpts2 = GenoconvertOptions {
-          _genoconvertBaseDirs = [testDir </> "Schiffels"]
-        , _genoconvertInGenos = []
+          _genoconvertGenoSources = [PacBaseDir $ testDir </> "Schiffels"]
         , _genoConvertOutFormat = GenotypeFormatPlink
         , _genoConvertOutOnlyGeno = False
         , _genoMaybeOutPackagePath = Just $ testDir </> "Schiffels"
@@ -248,18 +246,18 @@ testPipelineGenoconvert testDir checkFilePath = do
         , "Schiffels" </> "Schiffels.fam"
         ]
     let genoconvertOpts3 = GenoconvertOptions {
-          _genoconvertBaseDirs = []
-        , _genoconvertInGenos = [
-            GenotypeDataSpec {
-                format   = GenotypeFormatEigenstrat
-              , genoFile = testDir </> "Schiffels" </> "geno.txt"
-              , genoFileChkSum = Nothing
-              , snpFile  = testDir </> "Schiffels" </> "snp.txt"
-              , snpFileChkSum = Nothing
-              , indFile  = testDir </> "Schiffels" </> "ind.txt"
-              , indFileChkSum = Nothing
-              , snpSet   = Just SNPSetOther
-            }
+          _genoconvertGenoSources = [
+            GenoDirect $
+              GenotypeDataSpec {
+                  format   = GenotypeFormatEigenstrat
+                , genoFile = testDir </> "Schiffels" </> "geno.txt"
+                , genoFileChkSum = Nothing
+                , snpFile  = testDir </> "Schiffels" </> "snp.txt"
+                , snpFileChkSum = Nothing
+                , indFile  = testDir </> "Schiffels" </> "ind.txt"
+                , indFileChkSum = Nothing
+                , snpSet   = Just SNPSetOther
+              }
           ]
         , _genoConvertOutFormat = GenotypeFormatPlink
         , _genoConvertOutOnlyGeno = True
@@ -330,8 +328,7 @@ testPipelineForge :: FilePath -> FilePath -> FilePath -> IO ()
 testPipelineForge testDir checkFilePath testEntityFiles = do
     -- forge test 1
     let forgeOpts1 = ForgeOptions { 
-          _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
-        , _forgeInGenos      = []
+          _forgeGenoSources  = [PacBaseDir $ testDir </> "Schiffels", PacBaseDir $ testDir </> "Wang"]
         , _forgeEntitySpec   = Left (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")
         , _forgeSnpFile      = Nothing
         , _forgeIntersect    = False
@@ -351,8 +348,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         ]
     -- forge test 2
     let forgeOpts2 = ForgeOptions { 
-          _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
-        , _forgeInGenos      = []
+          _forgeGenoSources  = [PacBaseDir $ testDir </> "Schiffels", PacBaseDir $ testDir </> "Wang"]
         , _forgeEntitySpec   = Left (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>,-<SAMPLE3>")
         , _forgeSnpFile      = Nothing
         , _forgeIntersect    = False
@@ -371,8 +367,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         ]
     -- forge test 3
     let forgeOpts3 = ForgeOptions { 
-          _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
-        , _forgeInGenos      = []
+          _forgeGenoSources  = [PacBaseDir $ testDir </> "Schiffels", PacBaseDir $ testDir </> "Wang"]
         , _forgeEntitySpec   = Right (testEntityFiles </> "goldenTestForgeFile1.txt")
         , _forgeSnpFile      = Nothing
         , _forgeIntersect    = False
@@ -394,8 +389,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         ]
     -- forge test 4
     let forgeOpts4 = ForgeOptions { 
-          _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
-        , _forgeInGenos      = []
+          _forgeGenoSources  = [PacBaseDir $ testDir </> "Schiffels", PacBaseDir $ testDir </> "Wang"]
         , _forgeEntitySpec   = Right (testEntityFiles </> "goldenTestForgeFile2.txt")
         , _forgeSnpFile      = Nothing
         , _forgeIntersect    = False
@@ -417,8 +411,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         ]
     -- forge test 5
     let forgeOpts5 = ForgeOptions { 
-          _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
-        , _forgeInGenos      = []
+          _forgeGenoSources  = [PacBaseDir $ testDir </> "Schiffels", PacBaseDir $ testDir </> "Wang"]
         , _forgeEntitySpec   = Left []
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatEigenstrat
@@ -438,28 +431,29 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         ]
     -- forge test 6 (direct genotype data input interface)
     let forgeOpts6 = ForgeOptions {
-          _forgeBaseDirs     = []
-        , _forgeInGenos      = [
-            GenotypeDataSpec {
-                format   = GenotypeFormatEigenstrat
-              , genoFile = testDir </> "Schiffels" </> "geno.txt"
-              , genoFileChkSum = Nothing
-              , snpFile  = testDir </> "Schiffels" </> "snp.txt"
-              , snpFileChkSum = Nothing
-              , indFile  = testDir </> "Schiffels" </> "ind.txt"
-              , indFileChkSum = Nothing
-              , snpSet   = Just SNPSetOther
-            },
-            GenotypeDataSpec {
-                format   = GenotypeFormatPlink
-              , genoFile = testDir </> "Wang" </> "Wang_2020.bed"
-              , genoFileChkSum = Nothing
-              , snpFile  = testDir </> "Wang" </> "Wang_2020.bim"
-              , snpFileChkSum = Nothing
-              , indFile  = testDir </> "Wang" </> "Wang_2020.fam"
-              , indFileChkSum = Nothing
-              , snpSet   = Just SNPSetOther
-            }
+          _forgeGenoSources = [
+            GenoDirect $
+              GenotypeDataSpec {
+                  format   = GenotypeFormatEigenstrat
+                , genoFile = testDir </> "Schiffels" </> "geno.txt"
+                , genoFileChkSum = Nothing
+                , snpFile  = testDir </> "Schiffels" </> "snp.txt"
+                , snpFileChkSum = Nothing
+                , indFile  = testDir </> "Schiffels" </> "ind.txt"
+                , indFileChkSum = Nothing
+                , snpSet   = Just SNPSetOther
+              },
+            GenoDirect $
+              GenotypeDataSpec {
+                  format   = GenotypeFormatPlink
+                , genoFile = testDir </> "Wang" </> "Wang_2020.bed"
+                , genoFileChkSum = Nothing
+                , snpFile  = testDir </> "Wang" </> "Wang_2020.bim"
+                , snpFileChkSum = Nothing
+                , indFile  = testDir </> "Wang" </> "Wang_2020.fam"
+                , indFileChkSum = Nothing
+                , snpSet   = Just SNPSetOther
+              }
           ]
         , _forgeEntitySpec   = Left (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")
         , _forgeIntersect    = False
@@ -480,19 +474,20 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         ]
     -- forge test 7 (mixed data input interface)
     let forgeOpts7 = ForgeOptions {
-          _forgeBaseDirs     = [testDir </> "Schiffels"]
-        , _forgeInGenos      = [
-            GenotypeDataSpec {
-                format   = GenotypeFormatPlink
-              , genoFile = testDir </> "Wang" </> "Wang_2020.bed"
-              , genoFileChkSum = Nothing
-              , snpFile  = testDir </> "Wang" </> "Wang_2020.bim"
-              , snpFileChkSum = Nothing
-              , indFile  = testDir </> "Wang" </> "Wang_2020.fam"
-              , indFileChkSum = Nothing
-              , snpSet   = Just SNPSetOther
-            }
-          ]
+          _forgeGenoSources  = [
+            PacBaseDir $ testDir </> "Schiffels",
+            GenoDirect $
+              GenotypeDataSpec {
+                  format   = GenotypeFormatPlink
+                , genoFile = testDir </> "Wang" </> "Wang_2020.bed"
+                , genoFileChkSum = Nothing
+                , snpFile  = testDir </> "Wang" </> "Wang_2020.bim"
+                , snpFileChkSum = Nothing
+                , indFile  = testDir </> "Wang" </> "Wang_2020.fam"
+                , indFileChkSum = Nothing
+                , snpSet   = Just SNPSetOther
+              }
+            ]
         , _forgeEntitySpec   = Left (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatEigenstrat


### PR DESCRIPTION
- fixes #182
- removed short options (-r + -g + -s + -i) for the direct genotype data input