### PR TITLE
Flexible entity input

### DIFF
--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -349,9 +349,9 @@ parseForgeEntitiesDirect = OP.option (OP.eitherReader readSignedEntities) (OP.lo
         \Negative selection is possible by prepending \"-\" to the entity you want to exclude \
         \(e.g. \"*package_1*, -<individual_1>, -group_1\"). \
         \forge will apply excludes and includes in order. If the first entity is negative, then forge \
-        \will assume you want to merge all individuals in the \
-        \packages found in the baseDirs (except the ones explicitly excluded) before the exclude entities are applied. \
-        \An empty forgeString, with no --forgeFile given, will therefore merge all available individuals.")
+        \will assume you want to merge all individuals in the packages found in the baseDirs (except the \
+        \ones explicitly excluded) before the exclude entities are applied. \
+        \An empty forgeString (and no --forgeFile) will therefore merge all available individuals.")
   where
     readSignedEntities s = case readEntitiesFromString s of
         Left e -> Left (show e)
@@ -375,7 +375,9 @@ parseForgeEntitiesFromFile = OP.strOption (OP.long "forgeFile" <>
     OP.help "A file with a list of packages, groups or individual samples. \
         \Works just as -f, but multiple values can also be separated by newline, not just by comma. \
         \Empty lines are ignored and comments start with \"#\", so everything after \"#\" is ignored \
-        \in one line.")
+        \in one line. \
+        \Multiple instances of -f and --forgeFile can be given. They will be evaluated according to their \
+        \input order on the command line.")
 
 parseFetchEntitiesFromFile :: OP.Parser FilePath
 parseFetchEntitiesFromFile = OP.strOption (OP.long "fetchFile" <>

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -351,20 +351,20 @@ parseForgeEntitiesDirect = OP.option (OP.eitherReader readSignedEntities) (OP.lo
         \forge will apply excludes and includes in order. If the first entity is negative, then forge \
         \will assume you want to merge all individuals in the \
         \packages found in the baseDirs (except the ones explicitly excluded) before the exclude entities are applied. \
-        \An empty forgeString, with no --forgeFile given, will therefore merge all available individuals." <> OP.value [])
+        \An empty forgeString, with no --forgeFile given, will therefore merge all available individuals.")
   where
     readSignedEntities s = case readEntitiesFromString s of
         Left e -> Left (show e)
         Right e -> Right e
 
 parseFetchEntitiesDirect :: OP.Parser EntitiesList
-parseFetchEntitiesDirect = concat <$> OP.many (OP.option (OP.eitherReader readEntities) (OP.long "fetchString" <>
+parseFetchEntitiesDirect = OP.option (OP.eitherReader readEntities) (OP.long "fetchString" <>
     OP.short 'f' <>
     OP.help "List of packages to be downloaded from the remote server. \
         \Package names should be wrapped in asterisks: *package_title*. \
         \You can combine multiple values with comma, so for example: \"*package_1*, *package_2*, *package_3*\". \
         \fetchString uses the same parser as forgeString, but does not allow excludes. If groups or individuals are \
-        \specified, then packages which include these groups or individuals are included in the download."))
+        \specified, then packages which include these groups or individuals are included in the download.")
   where
     readEntities s = case readEntitiesFromString s of
         Left e -> Left (show e)

--- a/src/Poseidon/CLI/Fetch.hs
+++ b/src/Poseidon/CLI/Fetch.hs
@@ -4,7 +4,7 @@ module Poseidon.CLI.Fetch where
 
 import           Poseidon.EntitiesList   (findNonExistentEntities,
                                           indInfoFindRelevantPackageNames,
-                                          EntityInput, readEntityInputs)
+                                          EntityInput, readEntityInputs, PoseidonEntity)
 import           Poseidon.MathHelpers    (roundTo, roundToStr)
 import           Poseidon.Package        (PackageReadOptions (..),
                                           PoseidonPackage (..),
@@ -40,10 +40,9 @@ import           System.IO               (hFlush, hPutStr, stderr)
 
 data FetchOptions = FetchOptions
     { _jaBaseDirs      :: [FilePath]
-    , _entityInput     :: [EntityInput]
+    , _entityInput     :: [EntityInput PoseidonEntity] -- Empty list = All packages
     , _remoteURL       :: String
     , _upgrade         :: Bool
-    , _downloadAllPacs :: Bool
     }
 
 data PackageState = NotLocal
@@ -62,7 +61,7 @@ pacReadOpts = defaultPackageReadOptions {
 
 -- | The main function running the Fetch command
 runFetch :: FetchOptions -> PoseidonLogIO ()
-runFetch (FetchOptions baseDirs entityInputs remoteURL upgrade downloadAllPacs) = do
+runFetch (FetchOptions baseDirs entityInputs remoteURL upgrade) = do
     
     let remote = remoteURL --"https://c107-224.cloud.gwdg.de"
         downloadDir = head baseDirs
@@ -90,10 +89,7 @@ runFetch (FetchOptions baseDirs entityInputs remoteURL upgrade downloadAllPacs) 
         logInfo "Determine requested packages... "
         let remotePacTitles = map pTitle remotePacList
         let desiredPacTitles =
-                if downloadAllPacs then
-                    remotePacTitles
-                else
-                    indInfoFindRelevantPackageNames entities remoteIndList
+                if null entities then remotePacTitles else indInfoFindRelevantPackageNames entities remoteIndList
         
         let desiredRemotePackages = filter (\x -> pTitle x `elem` desiredPacTitles) remotePacList
 

--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -5,8 +5,6 @@ module Poseidon.CLI.Forge where
 import           Poseidon.BibFile            (BibEntry (..), BibTeX,
                                               writeBibTeXFile)
 import           Poseidon.EntitiesList       (PoseidonEntity (..), SignedEntity(..),
-                                              SignedEntitiesList,
-                                              readEntitiesFromFile,
                                               findNonExistentEntities,
                                               filterRelevantPackages,
                                               conformingEntityIndices, 
@@ -55,7 +53,7 @@ import           System.FilePath             (takeBaseName, (<.>), (</>))
 data ForgeOptions = ForgeOptions
     { _forgeBaseDirs     :: [FilePath]
     , _forgeInGenos      :: [GenotypeDataSpec]
-    , _forgeEntityInput  :: [EntityInput]
+    , _forgeEntityInput  :: [EntityInput SignedEntity] -- Empty list = forge all packages
     , _forgeSnpFile      :: Maybe FilePath
     , _forgeIntersect    :: Bool
     , _forgeOutFormat    :: GenotypeFormatSpec
@@ -63,7 +61,7 @@ data ForgeOptions = ForgeOptions
     , _forgeOutOnlyGeno  :: Bool
     , _forgeOutPacPath   :: FilePath
     , _forgeOutPacName   :: Maybe String
-    , _forgeLogMode     :: LogMode
+    , _forgeLogMode      :: LogMode
     , _forgeNoExtract    :: Bool
     }
 
@@ -84,13 +82,6 @@ runForge (
                  outFormat minimal onlyGeno outPath maybeOutName  
                  logMode noExtract 
     ) = do
-
-    -- compile entities
-    entitiesInput <- readEntityInputs entityInputs 
-
-    let printEntityList = (intercalate ", " . map show . take 10) entitiesInput ++
-            if length entitiesInput > 10 then " and " ++ show (length entitiesInput - 10) ++ " more" else ""
-    logInfo $ pack $ "Forging with the following entity-list: " ++ printEntityList
     
     -- load packages --
     properPackages <- readPoseidonPackageCollection pacReadOpts baseDirs
@@ -98,15 +89,22 @@ runForge (
     logInfo $ pack $ "Unpackaged genotype data files loaded: " ++ show (length pseudoPackages)
     let allPackages = properPackages ++ pseudoPackages
 
-    -- fill entitiesToInclude with all packages, if entitiesInput starts with an Exclude
-    let addImplicits = do
-            logInfo "forge entities begin with exclude or are empty, so implicitly adding all packages as includes before \
-            \applying excludes."
-            return $ map (Include . Pac . posPacTitle) allPackages ++ entitiesInput -- add all Packages to the front of the list
-    entities <- case entitiesInput of
-        (Include _:_) -> return entitiesInput
-        (Exclude _:_) -> addImplicits
-        []            -> addImplicits
+    -- compile entities
+    entitiesUser <- readEntityInputs entityInputs 
+
+    entities <- case entitiesUser of
+        [] -> do
+            logInfo $ "No requested entities. Implicitly forging all packages."
+            return $ map (Include . Pac . posPacTitle) allPackages
+        (Include _:_) -> do
+            return entitiesUser
+        (Exclude _:_) -> do
+            -- fill entitiesToInclude with all packages, if entitiesInput starts with an Exclude
+            logInfo "forge entities begin with exclude, so implicitly adding all packages as includes before \
+                \applying excludes."
+            return $ map (Include . Pac . posPacTitle) allPackages ++ entitiesUser -- add all Packages to the front of the list
+    logInfo . pack $ "Forging with the following entity-list: " ++ (intercalate ", " . map show . take 10) entities ++
+        if length entities > 10 then " and " ++ show (length entities - 10) ++ " more" else ""
 
     -- check for entities that do not exist this this dataset
     let nonExistentEntities = findNonExistentEntities entities . getJointIndividualInfo $ allPackages

--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -9,7 +9,8 @@ import           Poseidon.EntitiesList       (PoseidonEntity (..), SignedEntity(
                                               readEntitiesFromFile,
                                               findNonExistentEntities,
                                               filterRelevantPackages,
-                                              conformingEntityIndices)
+                                              conformingEntityIndices, 
+                                              EntityInput, readEntityInputs)
 import           Poseidon.GenotypeData       (GenotypeDataSpec (..),
                                               GenotypeFormatSpec (..),
                                               SNPSetSpec (..),
@@ -54,7 +55,7 @@ import           System.FilePath             (takeBaseName, (<.>), (</>))
 data ForgeOptions = ForgeOptions
     { _forgeBaseDirs     :: [FilePath]
     , _forgeInGenos      :: [GenotypeDataSpec]
-    , _forgeEntitySpec   :: Either SignedEntitiesList FilePath
+    , _forgeEntityInput  :: [EntityInput]
     , _forgeSnpFile      :: Maybe FilePath
     , _forgeIntersect    :: Bool
     , _forgeOutFormat    :: GenotypeFormatSpec
@@ -79,15 +80,13 @@ pacReadOpts = defaultPackageReadOptions {
 runForge :: ForgeOptions -> PoseidonLogIO ()
 runForge (
     ForgeOptions baseDirs inGenos
-                 entitySpec maybeSnpFile intersect_ 
+                 entityInputs maybeSnpFile intersect_ 
                  outFormat minimal onlyGeno outPath maybeOutName  
                  logMode noExtract 
     ) = do
 
     -- compile entities
-    entitiesInput <- case entitySpec of
-        Left e -> return e
-        Right fp -> liftIO $ readEntitiesFromFile fp
+    entitiesInput <- readEntityInputs entityInputs 
 
     let printEntityList = (intercalate ", " . map show . take 10) entitiesInput ++
             if length entitiesInput > 10 then " and " ++ show (length entitiesInput - 10) ++ " more" else ""

--- a/test/Poseidon/GoldenTestsRunCommands.hs
+++ b/test/Poseidon/GoldenTestsRunCommands.hs
@@ -4,7 +4,7 @@ module Poseidon.GoldenTestsRunCommands (
     createStaticCheckSumFile, createDynamicCheckSumFile, staticCheckSumFile, dynamicCheckSumFile
     ) where
 
-import           Poseidon.EntitiesList          (readEntitiesFromString, PoseidonEntity(..))
+import           Poseidon.EntitiesList          (readEntitiesFromString, PoseidonEntity(..), EntityInput(..))
 import           Poseidon.CLI.Update            (UpdateOptions (..), runUpdate)
 import           Poseidon.CLI.Genoconvert       (GenoconvertOptions (..), runGenoconvert)
 import           Poseidon.CLI.Init              (InitOptions (..), runInit)
@@ -332,7 +332,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
     let forgeOpts1 = ForgeOptions { 
           _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
         , _forgeInGenos      = []
-        , _forgeEntitySpec   = Left (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")
+        , _forgeEntityInput  = [EntitiesDirect (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")]
         , _forgeSnpFile      = Nothing
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatEigenstrat
@@ -353,7 +353,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
     let forgeOpts2 = ForgeOptions { 
           _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
         , _forgeInGenos      = []
-        , _forgeEntitySpec   = Left (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>,-<SAMPLE3>")
+        , _forgeEntityInput  = [EntitiesDirect (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>,-<SAMPLE3>")]
         , _forgeSnpFile      = Nothing
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatPlink
@@ -373,7 +373,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
     let forgeOpts3 = ForgeOptions { 
           _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
         , _forgeInGenos      = []
-        , _forgeEntitySpec   = Right (testEntityFiles </> "goldenTestForgeFile1.txt")
+        , _forgeEntityInput  = [EntitiesFromFile (testEntityFiles </> "goldenTestForgeFile1.txt")]
         , _forgeSnpFile      = Nothing
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatEigenstrat
@@ -396,7 +396,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
     let forgeOpts4 = ForgeOptions { 
           _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
         , _forgeInGenos      = []
-        , _forgeEntitySpec   = Right (testEntityFiles </> "goldenTestForgeFile2.txt")
+        , _forgeEntityInput  = [EntitiesFromFile (testEntityFiles </> "goldenTestForgeFile2.txt")]
         , _forgeSnpFile      = Nothing
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatPlink
@@ -419,7 +419,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
     let forgeOpts5 = ForgeOptions { 
           _forgeBaseDirs     = [testDir </> "Schiffels", testDir </> "Wang"]
         , _forgeInGenos      = []
-        , _forgeEntitySpec   = Left []
+        , _forgeEntityInput  = []
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatEigenstrat
         , _forgeOutMinimal   = False
@@ -461,7 +461,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
               , snpSet   = Just SNPSetOther
             }
           ]
-        , _forgeEntitySpec   = Left (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")
+        , _forgeEntityInput  = [EntitiesDirect (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")]
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatEigenstrat
         , _forgeOutMinimal   = False
@@ -493,7 +493,7 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
               , snpSet   = Just SNPSetOther
             }
           ]
-        , _forgeEntitySpec   = Left (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")
+        , _forgeEntityInput  = [EntitiesDirect (fromRight [] $ readEntitiesFromString "POP2,<SAMPLE2>,<SAMPLE4>")]
         , _forgeIntersect    = False
         , _forgeOutFormat    = GenotypeFormatEigenstrat
         , _forgeOutMinimal   = False
@@ -521,11 +521,9 @@ testPipelineFetch :: FilePath -> FilePath -> IO ()
 testPipelineFetch testDir checkFilePath = do
     let fetchOpts1 = FetchOptions { 
           _jaBaseDirs       = [testDir]
-        , _entityList       = [Pac "2019_Nikitin_LBK"]
-        , _entityFiles      = []
+        , _entityInput      = [EntitiesDirect [Pac "2019_Nikitin_LBK"]]
         , _remoteURL        = "http://c107-224.cloud.gwdg.de:3000"
         , _upgrade          = True
-        , _downloadAllPacs  = False 
         }
     runAndChecksumFiles checkFilePath testDir (usePoseidonLogger NoLog $ runFetch fetchOpts1) "fetch" [
           "2019_Nikitin_LBK" </> "POSEIDON.yml"


### PR DESCRIPTION
This should address #183. I made a few changes to the internal representation of direct Entity input and File input. Now the CLI should already guard against any non-sensical input (for example, using `--downloadAll` and entering entities in `fetch` was previously possible, but it shouldn't, and it isn't with this PR).

Note that despite the internal change, the CLI behaviour hasn't changed (for reasonable input). For example, with `forge`, if the user supplies neither a forgeString nor a forgeFile, it means that everything is forged. In `fetch`, the user _has_ to choose `--downloadAll` or give input through a direct string or file. One might want to debate whether this difference between fetch and forge is OK, but at least this is how it behaved so far. Internally, in both cases we now represent an empty list of strings and files as "forge or fetch all".