### PR TITLE
Adapted Logging

### DIFF
--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -24,7 +24,7 @@ library
     hs-source-dirs:     src
     build-depends:      base >= 4.7 && < 5, sequence-formats>=1.6.1, text, time, pipes-safe,
                         exceptions, pipes, bytestring, filepath, yaml, aeson, directory, parsec,
-                        vector, pipes-ordered-zip, table-layout,
+                        vector, pipes-ordered-zip, table-layout, mtl,
                         cassava, ansi-terminal, pureMD5, transformers,
                         yaml-pretty-extras, http-conduit, conduit, http-types, zip-archive,
                         unordered-containers, network-uri, optparse-applicative, co-log

--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -4,38 +4,40 @@ module Poseidon.CLI.Forge where
 
 import           Poseidon.BibFile            (BibEntry (..), BibTeX,
                                               writeBibTeXFile)
-import           Poseidon.EntitiesList       (PoseidonEntity (..), SignedEntity(..),
-                                              findNonExistentEntities,
+import           Poseidon.EntitiesList       (EntityInput, PoseidonEntity (..),
+                                              SignedEntity (..),
+                                              conformingEntityIndices,
                                               filterRelevantPackages,
-                                              conformingEntityIndices, 
-                                              EntityInput, readEntityInputs)
-import           Poseidon.GenotypeData       (GenotypeDataSpec (..),
+                                              findNonExistentEntities,
+                                              readEntityInputs)
+import           Poseidon.GenotypeData       (GenoDataSource (..),
+                                              GenotypeDataSpec (..),
                                               GenotypeFormatSpec (..),
                                               SNPSetSpec (..),
                                               printSNPCopyProgress,
-                                              selectIndices, snpSetMergeList,
-                                              selectIndices, GenoDataSource (..))
+                                              selectIndices, selectIndices,
+                                              snpSetMergeList)
 import           Poseidon.Janno              (JannoList (..), JannoRow (..),
                                               writeJannoFile)
 import           Poseidon.Package            (PackageReadOptions (..),
                                               PoseidonPackage (..),
                                               defaultPackageReadOptions,
                                               getJointGenotypeData,
+                                              getJointIndividualInfo,
+                                              getJointJanno,
+                                              makePseudoPackageFromGenotypeData,
                                               newMinimalPackageTemplate,
                                               newPackageTemplate,
                                               readPoseidonPackageCollection,
-                                              writePoseidonPackage,
-                                              getJointIndividualInfo,
-                                              getJointJanno,
-                                              makePseudoPackageFromGenotypeData)
-import           Poseidon.Utils              (PoseidonException (..), PoseidonLogIO, LogMode)
+                                              writePoseidonPackage)
+import           Poseidon.Utils              (PoseidonException (..),
+                                              PoseidonLogIO, logInfo, logWarning)
 
-import           Colog                       (logInfo, logWarning)
 import           Control.Exception           (throwIO)
 import           Control.Monad               (forM, forM_, unless, when)
+import           Control.Monad.Reader        (ask)
 import           Data.List                   (intercalate, nub, (\\))
 import           Data.Maybe                  (mapMaybe)
-import           Data.Text                   (pack)
 import qualified Data.Vector                 as V
 import qualified Data.Vector.Unboxed         as VU
 import qualified Data.Vector.Unboxed.Mutable as VUM
@@ -51,17 +53,17 @@ import           System.FilePath             (takeBaseName, (<.>), (</>))
 
 -- | A datatype representing command line options for the survey command
 data ForgeOptions = ForgeOptions
-    { _forgeGenoSources  :: [GenoDataSource]
-    , _forgeEntityInput  :: [EntityInput SignedEntity] -- Empty list = forge all packages
-    , _forgeSnpFile      :: Maybe FilePath
-    , _forgeIntersect    :: Bool
-    , _forgeOutFormat    :: GenotypeFormatSpec
-    , _forgeOutMinimal   :: Bool
-    , _forgeOutOnlyGeno  :: Bool
-    , _forgeOutPacPath   :: FilePath
-    , _forgeOutPacName   :: Maybe String
-    , _forgeLogMode      :: LogMode
-    , _forgeNoExtract    :: Bool
+    { _forgeGenoSources :: [GenoDataSource]
+    -- Empty list = forge all packages
+    , _forgeEntityInput :: [EntityInput SignedEntity] -- Empty list = forge all packages
+    , _forgeSnpFile     :: Maybe FilePath
+    , _forgeIntersect   :: Bool
+    , _forgeOutFormat   :: GenotypeFormatSpec
+    , _forgeOutMinimal  :: Bool
+    , _forgeOutOnlyGeno :: Bool
+    , _forgeOutPacPath  :: FilePath
+    , _forgeOutPacName  :: Maybe String
+    , _forgeNoExtract   :: Bool
     }
 
 pacReadOpts :: PackageReadOptions
@@ -77,19 +79,19 @@ pacReadOpts = defaultPackageReadOptions {
 runForge :: ForgeOptions -> PoseidonLogIO ()
 runForge (
     ForgeOptions genoSources
-                 entityInputs maybeSnpFile intersect_ 
-                 outFormat minimal onlyGeno outPath maybeOutName  
-                 logMode noExtract 
+                 entityInputs maybeSnpFile intersect_
+                 outFormat minimal onlyGeno outPath maybeOutName
+                 noExtract
     ) = do
-    
+
     -- load packages --
     properPackages <- readPoseidonPackageCollection pacReadOpts $ [getPacBaseDirs x | x@PacBaseDir {} <- genoSources]
     pseudoPackages <- liftIO $ mapM makePseudoPackageFromGenotypeData $ [getGenoDirect x | x@GenoDirect {} <- genoSources]
-    logInfo $ pack $ "Unpackaged genotype data files loaded: " ++ show (length pseudoPackages)
+    logInfo $ "Unpackaged genotype data files loaded: " ++ show (length pseudoPackages)
     let allPackages = properPackages ++ pseudoPackages
 
     -- compile entities
-    entitiesUser <- readEntityInputs entityInputs 
+    entitiesUser <- readEntityInputs entityInputs
 
     entities <- case entitiesUser of
         [] -> do
@@ -102,18 +104,18 @@ runForge (
             logInfo "forge entities begin with exclude, so implicitly adding all packages as includes before \
                 \applying excludes."
             return $ map (Include . Pac . posPacTitle) allPackages ++ entitiesUser -- add all Packages to the front of the list
-    logInfo . pack $ "Forging with the following entity-list: " ++ (intercalate ", " . map show . take 10) entities ++
+    logInfo $ "Forging with the following entity-list: " ++ (intercalate ", " . map show . take 10) entities ++
         if length entities > 10 then " and " ++ show (length entities - 10) ++ " more" else ""
 
     -- check for entities that do not exist this this dataset
     let nonExistentEntities = findNonExistentEntities entities . getJointIndividualInfo $ allPackages
     unless (null nonExistentEntities) $
-        logWarning $ pack $ "The following entities do not exist in this dataset and will be ignored: " ++
+        logWarning $ "The following entities do not exist in this dataset and will be ignored: " ++
             intercalate ", " (map show nonExistentEntities)
-    
+
     -- determine relevant packages
     let relevantPackages = filterRelevantPackages entities allPackages
-    logInfo $ pack $ (show . length $ relevantPackages) ++ " packages contain data for this forging operation"
+    logInfo $ (show . length $ relevantPackages) ++ " packages contain data for this forging operation"
     when (null relevantPackages) $ liftIO $ throwIO PoseidonEmptyForgeException
 
     -- determine relevant individual indices
@@ -123,7 +125,7 @@ runForge (
     -- janno
     let jannoRows = getJointJanno relevantPackages
         relevantJannoRows = map (jannoRows !!) relevantIndices
-    
+
     -- check for duplicates among the individuals selected for merging
     checkIndividualsUniqueJanno relevantJannoRows
     -- bib
@@ -136,7 +138,7 @@ runForge (
             Nothing -> takeBaseName outPath
     when (outName == "") $ liftIO $ throwIO PoseidonEmptyOutPacNameException
     -- create new directory
-    logInfo $ pack $ "Writing to directory (will be created if missing): " ++ outPath
+    logInfo $ "Writing to directory (will be created if missing): " ++ outPath
     liftIO $ createDirectoryIfMissing True outPath
     -- compile genotype data structure
     let [outInd, outSnp, outGeno] = case outFormat of
@@ -154,7 +156,7 @@ runForge (
     pac <- if minimal
            then return $ newMinimalPackageTemplate outPath outName genotypeData
            else liftIO $ newPackageTemplate outPath outName genotypeData (Just (Right relevantJannoRows)) relevantBibEntries
-    
+
     -- write new package to the file system --
     -- POSEIDON.yml
     unless onlyGeno $ do
@@ -167,8 +169,9 @@ runForge (
     -- genotype data
     logInfo "Compiling genotype data"
     logInfo "Processing SNPs..."
+    logEnv <- ask
     newNrSNPs <- liftIO $ runSafeT $ do
-        (eigenstratIndEntries, eigenstratProd) <- getJointGenotypeData logMode intersect_ relevantPackages maybeSnpFile
+        (eigenstratIndEntries, eigenstratProd) <- getJointGenotypeData logEnv intersect_ relevantPackages maybeSnpFile
         let eigenstratIndEntriesV = eigenstratIndEntries
         let newEigenstratIndEntries = map (eigenstratIndEntriesV !!) relevantIndices
 
@@ -228,6 +231,6 @@ fillMissingSnpSets packages = forM packages $ \pac -> do
     case maybeSnpSet of
         Just s -> return s
         Nothing -> do
-            logWarning $ pack $ ("Warning for package " ++ title_ ++ ": field \"snpSet\" \
-            \is not set. I will interpret this as \"snpSet: Other\"")
+            logWarning $ "Warning for package " ++ title_ ++ ": field \"snpSet\" \
+                \is not set. I will interpret this as \"snpSet: Other\""
             return SNPSetOther

--- a/src/Poseidon/CLI/Init.hs
+++ b/src/Poseidon/CLI/Init.hs
@@ -11,13 +11,11 @@ import           Poseidon.Package           (PoseidonPackage (..),
                                              newPackageTemplate,
                                              newMinimalPackageTemplate,
                                              writePoseidonPackage)
-import           Poseidon.Utils              (PoseidonException (..), PoseidonLogIO)
+import           Poseidon.Utils              (PoseidonException (..), PoseidonLogIO, logInfo)
 
-import           Colog                      (logInfo)
 import           Control.Exception          (throwIO)
 import           Control.Monad              (unless, when)
 import           Control.Monad.IO.Class     (liftIO)
-import           Data.Text                  (pack)
 import           System.Directory           (createDirectoryIfMissing, copyFile)
 import           System.FilePath            ((<.>), (</>), takeFileName, takeBaseName)
 
@@ -31,7 +29,7 @@ data InitOptions = InitOptions
 runInit :: InitOptions -> PoseidonLogIO ()
 runInit (InitOptions (GenotypeDataSpec format_ genoFile_ _ snpFile_ _ indFile_ _ snpSet_) outPath maybeOutName minimal) = do
     -- create new directory
-    logInfo $ pack $ "Creating new package directory: " ++ outPath
+    logInfo $ "Creating new package directory: " ++ outPath
     liftIO $ createDirectoryIfMissing True outPath
     -- compile genotype data structure
     let outInd = takeFileName indFile_

--- a/src/Poseidon/CLI/List.hs
+++ b/src/Poseidon/CLI/List.hs
@@ -6,16 +6,14 @@ import           Poseidon.Janno             (JannoRow (..), JannoList(..))
 import           Poseidon.Package           (PoseidonPackage (..),
                                              readPoseidonPackageCollection,
                                              PackageReadOptions (..), defaultPackageReadOptions)
-import           Poseidon.Utils             (PoseidonException (..), PoseidonLogIO)
+import           Poseidon.Utils             (PoseidonException (..), PoseidonLogIO, logInfo)
 
-import           Colog                      (logInfo)
 import           Control.Exception          (throwIO)
 import           Control.Monad              (forM)
 import           Control.Monad.IO.Class     (liftIO)
 import           Data.Aeson                 (eitherDecode')
 import qualified Data.ByteString.Lazy       as LB
 import           Data.List                  (group, intercalate, sortOn)
-import           Data.Text                  (pack)
 import           Network.HTTP.Conduit       (simpleHttp)
 import           Text.Layout.Table          (asciiRoundS, column, def,
                                              expandUntil, rowsG, tableString,
@@ -62,7 +60,7 @@ runList (ListOptions repoLocation listEntity rawOutput ignoreGeno) = do
         ListPackages -> do
             let tableH = ["Title", "Nr Individuals"]
                 tableB = [[name, show (length rows)] | (name, rows) <- sortOn fst allSampleInfo]
-            logInfo $ pack ("found " ++ show (length tableB) ++ " packages")
+            logInfo $ "found " ++ show (length tableB) ++ " packages"
             return (tableH, tableB)
         ListGroups -> do
             let tableH = ["Group", "Packages", "Nr Individuals"]
@@ -77,7 +75,7 @@ runList (ListOptions repoLocation listEntity rawOutput ignoreGeno) = do
                         groupPacs = head $ map fst oneGroup
                         groupNrInds = show (length oneGroup)
                     return [groupName, groupPacs, groupNrInds]
-            logInfo $ pack ("found " ++ show (length tableB) ++ " groups/populations")
+            logInfo $ "found " ++ show (length tableB) ++ " groups/populations"
             return (tableH, tableB)
         ListIndividuals moreJannoColumns -> do
             let tableH = ["Package", "Individual", "Group"] ++ moreJannoColumns
@@ -85,7 +83,7 @@ runList (ListOptions repoLocation listEntity rawOutput ignoreGeno) = do
                 forM rows (\row -> do
                     moreFields <- liftIO $ extractAdditionalFields row moreJannoColumns
                     return ([pacName, jPoseidonID row, head . getJannoList . jGroupName $ row] ++ moreFields))
-            logInfo $ pack ("found " ++ show (length tableB) ++ " individuals/samples")
+            logInfo $ "found " ++ show (length tableB) ++ " individuals/samples"
             return (tableH, tableB)
     if rawOutput then
         liftIO $ putStrLn $ intercalate "\n" [intercalate "\t" row | row <- tableB]

--- a/src/Poseidon/CLI/Survey.hs
+++ b/src/Poseidon/CLI/Survey.hs
@@ -10,9 +10,8 @@ import           Poseidon.Package       (PackageReadOptions (..),
                                          PoseidonPackage (..),
                                          defaultPackageReadOptions,
                                          readPoseidonPackageCollection)
-import           Poseidon.Utils          (PoseidonLogIO)
+import           Poseidon.Utils          (PoseidonLogIO, logInfo)
 
-import           Colog                  (logInfo)
 import           Control.Monad          (forM)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.List              (intercalate, zip4, unfoldr)

--- a/src/Poseidon/CLI/Update.hs
+++ b/src/Poseidon/CLI/Update.hs
@@ -13,9 +13,8 @@ import           Poseidon.Package           (PoseidonPackage (..),
                                              getChecksum)
 import           Poseidon.SecondaryTypes    (ContributorSpec (..),
                                             VersionComponent (..))
-import           Poseidon.Utils             (PoseidonLogIO)
+import           Poseidon.Utils             (PoseidonLogIO, logInfo, logWarning)
 
-import           Colog                      (logInfo, logWarning)
 import           Control.Monad.IO.Class     (liftIO)
 import           Data.List                  (nub)
 import           Data.Maybe                 (fromMaybe, isNothing, fromJust)

--- a/src/Poseidon/CLI/Validate.hs
+++ b/src/Poseidon/CLI/Validate.hs
@@ -8,9 +8,8 @@ import           Poseidon.Package  (PoseidonPackage (..),
                                    findAllPoseidonYmlFiles,
                                    readPoseidonPackageCollection,
                                    PackageReadOptions (..), defaultPackageReadOptions)
-import           Poseidon.Utils    (PoseidonLogIO)
+import           Poseidon.Utils    (PoseidonLogIO, logInfo, logError)
 
-import           Colog             (logInfo, logError)
 import           Control.Monad     (unless)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.List         (foldl')

--- a/src/Poseidon/GenotypeData.hs
+++ b/src/Poseidon/GenotypeData.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Poseidon.GenotypeData where
 
-import           Poseidon.Utils             (PoseidonException (..))
+import           Poseidon.Utils             (LogEnv, PoseidonException (..),
+                                             logDebug, logWithEnv)
 
 import           Control.Exception          (throwIO)
 import           Control.Monad              (forM, when)
@@ -11,12 +12,12 @@ import           Data.Aeson                 (FromJSON, ToJSON, object,
                                              parseJSON, toJSON, withObject,
                                              withText, (.:), (.:?), (.=))
 import           Data.ByteString            (isPrefixOf)
-import           Data.IORef (newIORef, readIORef, modifyIORef)
+import           Data.IORef                 (modifyIORef, newIORef, readIORef)
 import           Data.List                  (nub, sort)
 import           Data.Maybe                 (catMaybes)
 import qualified Data.Text                  as T
 import qualified Data.Vector                as V
-import           Pipes                      (Pipe, Producer, for, yield, cat)
+import           Pipes                      (Pipe, Producer, cat, for, yield)
 import           Pipes.Safe                 (MonadSafe)
 import           SequenceFormats.Eigenstrat (EigenstratIndEntry (..),
                                              EigenstratSnpEntry (..),
@@ -27,9 +28,12 @@ import           System.Console.ANSI        (hClearLine, hSetCursorColumn)
 import           System.FilePath            ((</>))
 import           System.IO                  (hFlush, hPutStr, stderr)
 
-data GenoDataSource =
-      PacBaseDir {getPacBaseDirs :: FilePath}
-    | GenoDirect {getGenoDirect :: GenotypeDataSpec}
+data GenoDataSource = PacBaseDir
+    { getPacBaseDirs :: FilePath
+    }
+    | GenoDirect
+    { getGenoDirect :: GenotypeDataSpec
+    }
     deriving Show
 
 -- | A datatype to specify genotype files
@@ -156,10 +160,10 @@ loadGenotypeData baseDir (GenotypeDataSpec format_ genoF _ snpF _ indF _ _) =
         GenotypeFormatEigenstrat -> readEigenstrat (baseDir </> genoF) (baseDir </> snpF) (baseDir </> indF)
         GenotypeFormatPlink      -> readPlink (baseDir </> genoF) (baseDir </> snpF) (baseDir </> indF)
 
-joinEntries :: (MonadIO m) => [Int] -> [String] -> [Maybe (EigenstratSnpEntry, GenoLine)] -> m ([String], EigenstratSnpEntry, GenoLine)
-joinEntries nrInds pacNames maybeTupleList = do
+joinEntries :: (MonadIO m) => LogEnv -> [Int] -> [String] -> [Maybe (EigenstratSnpEntry, GenoLine)] -> m (EigenstratSnpEntry, GenoLine)
+joinEntries logEnv nrInds pacNames maybeTupleList = do
     let allSnpEntries = map fst . catMaybes $ maybeTupleList
-    (consensusSnpEntryWarnings, consensusSnpEntry) <- getConsensusSnpEntry allSnpEntries
+    consensusSnpEntry <- getConsensusSnpEntry logEnv allSnpEntries
     recodedGenotypes <- forM (zip3 nrInds pacNames maybeTupleList) $ \(n, name, maybeTuple) ->
         case maybeTuple of
             Nothing -> return (V.replicate n Missing)
@@ -168,10 +172,10 @@ joinEntries nrInds pacNames maybeTupleList = do
                     let msg = "Error in genotype data of package " ++ name ++ ": " ++ err
                     liftIO . throwIO $ PoseidonGenotypeException msg
                 Right x -> return x
-    return (consensusSnpEntryWarnings, consensusSnpEntry, V.concat recodedGenotypes)
+    return (consensusSnpEntry, V.concat recodedGenotypes)
 
-getConsensusSnpEntry :: (MonadIO m) => [EigenstratSnpEntry] -> m ([String], EigenstratSnpEntry)
-getConsensusSnpEntry snpEntries = do
+getConsensusSnpEntry :: (MonadIO m) => LogEnv -> [EigenstratSnpEntry] -> m EigenstratSnpEntry
+getConsensusSnpEntry logEnv snpEntries = do
     let chrom = snpChrom . head $ snpEntries
         pos = snpPos . head $ snpEntries
         uniqueIds = nub . map snpId $ snpEntries
@@ -179,41 +183,35 @@ getConsensusSnpEntry snpEntries = do
         allAlleles    = concat $ [[r, a] | EigenstratSnpEntry _ _ _ _ r a <- snpEntries]
         uniqueAlleles = nub . filter (\a -> a /= 'N' && a /= '0' && a /= 'X') $ allAlleles
     id_ <- case uniqueIds of
-        [i] -> return (Nothing, i)
+        [i] -> return i
         _ -> do -- multiple Ids: Picking the first rs-number if possible, otherwise the first one.
             let rsIds = filter (isPrefixOf "rs") uniqueIds
                 selectedId = case rsIds of
                     (i:_) -> i
                     _     -> head uniqueIds
-            return (
-                Just $ "Found inconsistent SNP IDs: " ++ show uniqueIds ++ ". Choosing " ++ show selectedId,
-                selectedId
-                )
+            logWithEnv logEnv . logDebug $
+                "Found inconsistent SNP IDs: " ++ show uniqueIds ++ ". Choosing " ++ show selectedId
+            return selectedId
     genPos <- case uniqueGenPos of
-        [p] -> return (Nothing, p)
-        [0.0, p] -> return (Nothing, p) -- 0.0 is considered "no data" in genetic position column
+        [p] -> return p
+        [0.0, p] -> return p -- 0.0 is considered "no data" in genetic position column
         _ -> do -- multiple non-zero genetic positions. Choosing the largest one.
             let selectedGenPos = maximum uniqueGenPos
-            return (
-                Just $ "Found inconsistent genetic positions in SNP " ++ show (snd id_) ++ ": " ++ show uniqueGenPos ++ ". Choosing " ++ show selectedGenPos,
-                selectedGenPos
-                )
+            logWithEnv logEnv . logDebug $
+                "Found inconsistent genetic positions in SNP " ++ show id_ ++ ": " ++
+                show uniqueGenPos ++ ". Choosing " ++ show selectedGenPos
+            return selectedGenPos
     case uniqueAlleles of
         [] -> do -- no non-missing alleles found
-            return (
-                catMaybes [fst id_, fst genPos, Just $ "SNP " ++ show (snd id_) ++ " appears to have no data (both ref and alt allele are blank"],
-                EigenstratSnpEntry chrom pos (snd genPos) (snd id_) 'N' 'N'
-                )
+            logWithEnv logEnv . logDebug $
+                "SNP " ++ show id_ ++ " appears to have no data (both ref and alt allele are blank"
+            return (EigenstratSnpEntry chrom pos genPos id_ 'N' 'N')
         [r] -> do -- only one non-missing allele found
-            return (
-                catMaybes [fst id_, fst genPos, Just $ "SNP " ++ show id_ ++ " appears to be monomorphic (only one of ref and alt alleles are non-blank)"],
-                EigenstratSnpEntry chrom pos (snd genPos) (snd id_) 'N' r
-                )
-        [ref, alt] -> 
-            return (
-                catMaybes [fst id_, fst genPos],
-                EigenstratSnpEntry chrom pos (snd genPos) (snd id_) ref alt
-            )
+            logWithEnv logEnv . logDebug $
+                "SNP " ++ show id_ ++ " appears to be monomorphic (only one of ref and alt alleles are non-blank)"
+            return (EigenstratSnpEntry chrom pos genPos id_ 'N' r)
+        [ref, alt] ->
+            return (EigenstratSnpEntry chrom pos genPos id_ ref alt)
         _ -> liftIO . throwIO $ PoseidonGenotypeException ("Incongruent alleles: " ++ show snpEntries)
 
 recodeAlleles :: EigenstratSnpEntry -> EigenstratSnpEntry -> GenoLine -> Either String GenoLine

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -113,28 +113,29 @@ logWithEnv :: (MonadIO m) => LogEnv -> PoseidonLogIO () -> m ()
 logWithEnv logEnv = liftIO . flip runReaderT logEnv
 
 -- | A Poseidon Exception data type with several concrete constructors
-data PoseidonException = PoseidonYamlParseException FilePath ParseException
-    | PoseidonPackageException String
-    | PoseidonPackageVersionException FilePath String
-    | PoseidonPackageMissingVersionException FilePath
-    | PoseidonIndSearchException String
-    | PoseidonGenotypeException String
-    | PoseidonJannoRowException FilePath Int String
-    | PoseidonJannoConsistencyException FilePath String
-    | PoseidonCrossFileConsistencyException String String
-    | PoseidonCollectionException String
-    | PoseidonFileExistenceException FilePath
-    | PoseidonFileChecksumException FilePath
-    | PoseidonFStatsFormatException String
-    | PoseidonBibTeXException FilePath String
-    | PoseidonPoseidonEntityParsingException String
-    | PoseidonForgeEntitiesException String
-    | PoseidonEmptyForgeException
-    | PoseidonNewPackageConstructionException String
-    | PoseidonRemoteJSONParsingException String
-    | PoseidonGenericException String
-    | PoseidonEmptyOutPacNameException
-    | PoseidonUnequalBaseDirException FilePath FilePath FilePath
+data PoseidonException = 
+    PoseidonYamlParseException FilePath ParseException -- ^ An exception to represent YAML parsing errors
+    | PoseidonPackageException String -- ^ An exception to represent a logical error in a package
+    | PoseidonPackageVersionException FilePath String -- ^ An exception to represent an issue with a package version 
+    | PoseidonPackageMissingVersionException FilePath -- ^ An exception to indicate a missing poseidonVersion field
+    | PoseidonIndSearchException String -- ^ An exception to represent an error when searching for individuals or populations
+    | PoseidonGenotypeException String -- ^ An exception to represent errors when trying to parse the genotype data
+    | PoseidonJannoRowException FilePath Int String -- ^ An exception to represent errors when trying to parse the .janno file
+    | PoseidonJannoConsistencyException FilePath String -- ^ An exception to represent within-janno consistency errors
+    | PoseidonCrossFileConsistencyException String String -- ^ An exception to represent inconsistencies across multiple files in a package
+    | PoseidonCollectionException String -- ^ An exception to represent logical issues in a poseidon package Collection
+    | PoseidonFileExistenceException FilePath -- ^ An exception to represent missing files
+    | PoseidonFileChecksumException FilePath -- ^ An exception to represent failed checksum tests
+    | PoseidonFStatsFormatException String -- ^ An exception type to represent FStat specification errors
+    | PoseidonBibTeXException FilePath String -- ^ An exception to represent errors when trying to parse the .bib file
+    | PoseidonPoseidonEntityParsingException String -- ^ An exception to indicate failed entity parsing
+    | PoseidonForgeEntitiesException String -- ^ An exception to indicate issues in the forge selection
+    | PoseidonEmptyForgeException -- ^ An exception to throw if there is nothing to be forged
+    | PoseidonNewPackageConstructionException String -- ^ An exception to indicate an issue in newPackageTemplate
+    | PoseidonRemoteJSONParsingException String -- ^ An exception to indicate failed remote info JSON parsing
+    | PoseidonGenericException String -- ^ A catch-all for any other type of exception
+    | PoseidonEmptyOutPacNameException -- ^ An exception to throw if the output package lacks a name
+    | PoseidonUnequalBaseDirException FilePath FilePath FilePath -- ^ An exception to throw if genotype data files don't share a common base directory
     deriving (Show)
 
 instance Exception PoseidonException

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, FlexibleInstances, MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Poseidon.Utils (
     PoseidonException (..),
@@ -11,7 +11,8 @@ module Poseidon.Utils (
     logDebug,
     logError,
     LogEnv,
-    noLog
+    noLog,
+    logWithEnv
 ) where
 
 import           Colog                  (LogAction (..), Message,
@@ -20,7 +21,7 @@ import           Colog                  (LogAction (..), Message,
                                          showSeverity, Msg(..), HasLog(..))
 import           Control.Exception      (Exception, IOException, try)
 import           Control.Monad          (when)
-import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.IO.Class (liftIO, MonadIO)
 import           Control.Monad.Reader   (ReaderT, runReaderT, asks)
 import           Data.Text              (Text, pack)
 import           Data.Time              (defaultTimeLocale, formatTime,
@@ -107,6 +108,9 @@ logDebug = logMsg Debug
 
 logError :: String -> PoseidonLogIO ()
 logError = logMsg Error
+
+logWithEnv :: (MonadIO m) => LogEnv -> PoseidonLogIO () -> m ()
+logWithEnv logEnv = liftIO . flip runReaderT logEnv
 
 -- | A Poseidon Exception data type with several concrete constructors
 data PoseidonException = PoseidonYamlParseException FilePath ParseException

--- a/test/Poseidon/GenotypeDataSpec.hs
+++ b/test/Poseidon/GenotypeDataSpec.hs
@@ -2,6 +2,7 @@
 module Poseidon.GenotypeDataSpec (spec) where
 
 import           Poseidon.GenotypeData
+import           Poseidon.Utils             (noLog)
 
 
 import qualified Data.Vector                as V
@@ -37,9 +38,8 @@ testEntriesTuplesList1 = [
     Just (EigenstratSnpEntry (Chrom "1") 1 0.1 "id1" 'C' 'N', V.fromList [HomRef, Missing, HomRef]),
     Just (EigenstratSnpEntry (Chrom "1") 1 0.1 "id1" 'N' 'A', V.fromList [HomAlt, HomAlt, HomAlt])]
 
-mergedTestEntries1 :: ([String], EigenstratSnpEntry, GenoLine)
+mergedTestEntries1 :: (EigenstratSnpEntry, GenoLine)
 mergedTestEntries1 = (
-    [],
     EigenstratSnpEntry (Chrom "1") 1 0.1 "id1" 'A' 'C',
     V.fromList [HomRef, Het, HomAlt,
                 Missing, Missing, Missing,
@@ -53,4 +53,4 @@ testJoinGenoEntries =
         it "should just work" $ do
             let nrInds = [3, 3, 3, 3, 3]
                 pacNames = ["Pac1", "Pac2", "Pac3", "Pac4", "Pac5"]
-            joinEntries nrInds pacNames testEntriesTuplesList1 `shouldReturn` mergedTestEntries1
+            joinEntries noLog nrInds pacNames testEntriesTuplesList1 `shouldReturn` mergedTestEntries1

--- a/test/Poseidon/GoldenTestsRunCommands.hs
+++ b/test/Poseidon/GoldenTestsRunCommands.hs
@@ -337,7 +337,6 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         , _forgeOutOnlyGeno  = False
         , _forgeOutPacPath   = testDir </> "ForgePac1"
         , _forgeOutPacName   = Just "ForgePac1"
-        , _forgeLogMode     = NoLog
         , _forgeNoExtract    = False
     }
     let action1 = usePoseidonLogger NoLog (runForge forgeOpts1) >> patchLastModified testDir ("ForgePac1" </> "POSEIDON.yml")
@@ -357,7 +356,6 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         , _forgeOutOnlyGeno  = False
         , _forgeOutPacPath   = testDir </> "ForgePac2"
         , _forgeOutPacName   = Nothing
-        , _forgeLogMode     = NoLog
         , _forgeNoExtract    = False
     }
     let action2 = usePoseidonLogger NoLog (runForge forgeOpts2) >> patchLastModified testDir ("ForgePac2" </> "POSEIDON.yml")
@@ -376,7 +374,6 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         , _forgeOutOnlyGeno  = False
         , _forgeOutPacPath   = testDir </> "ForgePac3"
         , _forgeOutPacName   = Nothing
-        , _forgeLogMode     = NoLog
         , _forgeNoExtract    = False
     }
     let action3 = usePoseidonLogger NoLog (runForge forgeOpts3) >> patchLastModified testDir ("ForgePac3" </> "POSEIDON.yml")
@@ -398,7 +395,6 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         , _forgeOutOnlyGeno  = False
         , _forgeOutPacPath   = testDir </> "ForgePac4"
         , _forgeOutPacName   = Nothing
-        , _forgeLogMode     = NoLog
         , _forgeNoExtract    = False
     }
     let action4 = usePoseidonLogger NoLog (runForge forgeOpts4) >> patchLastModified testDir ("ForgePac4" </> "POSEIDON.yml")
@@ -419,7 +415,6 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         , _forgeOutOnlyGeno  = False
         , _forgeOutPacPath   = testDir </> "ForgePac5"
         , _forgeOutPacName   = Just "ForgePac5"
-        , _forgeLogMode     = NoLog
         , _forgeNoExtract    = False
         , _forgeSnpFile      = Nothing
     }
@@ -462,7 +457,6 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         , _forgeOutOnlyGeno  = True
         , _forgeOutPacPath   = testDir </> "ForgePac6"
         , _forgeOutPacName   = Just "ForgePac6"
-        , _forgeLogMode     = NoLog
         , _forgeNoExtract    = False
         , _forgeSnpFile      = Nothing
     }
@@ -495,7 +489,6 @@ testPipelineForge testDir checkFilePath testEntityFiles = do
         , _forgeOutOnlyGeno  = False
         , _forgeOutPacPath   = testDir </> "ForgePac7"
         , _forgeOutPacName   = Just "ForgePac7"
-        , _forgeLogMode     = NoLog
         , _forgeNoExtract    = False
         , _forgeSnpFile      = Nothing
     }

--- a/test/Poseidon/PackageSpec.hs
+++ b/test/Poseidon/PackageSpec.hs
@@ -14,7 +14,7 @@ import           Poseidon.Package           (PackageReadOptions (..),
                                              readPoseidonPackageCollection,
                                              renderMismatch, zipWithPadding)
 import           Poseidon.SecondaryTypes    (ContributorSpec (..))
-import           Poseidon.Utils             (usePoseidonLogger, LogMode (..))
+import           Poseidon.Utils             (usePoseidonLogger, noLog, LogMode(..))
 
 import qualified Data.ByteString.Char8      as B
 import           Data.List                  (sort)
@@ -214,9 +214,9 @@ testGetJoinGenotypeData = describe "Poseidon.Package.getJointGenotypeData" $ do
     let pacFiles = ["test/testDat/testPackages/ancient/Lamnidis_2018/POSEIDON.yml",
                     "test/testDat/testPackages/ancient/Schiffels_2016/POSEIDON.yml"]
     it "should correctly load genotype data without intersect" $ do
-        pacs <- mapM (readPoseidonPackage testPacReadOpts) pacFiles
+        pacs <- usePoseidonLogger NoLog $ mapM (readPoseidonPackage testPacReadOpts) pacFiles
         jointDat <- runSafeT $ do
-            (_, jointProd) <- getJointGenotypeData NoLog False pacs Nothing
+            (_, jointProd) <- getJointGenotypeData noLog False pacs Nothing
             P.toListM jointProd
         length jointDat `shouldBe` 10
         jointDat !! 3 `shouldBe` (EigenstratSnpEntry (Chrom "1") 903426 0.024457 "1_903426" 'C' 'T',
@@ -224,9 +224,9 @@ testGetJoinGenotypeData = describe "Poseidon.Package.getJointGenotypeData" $ do
         jointDat !! 5 `shouldBe` (EigenstratSnpEntry (Chrom "2") 1018704 0.026288 "2_1018704" 'A' 'G',
                                   V.fromList $ replicate 10 Missing ++ [Het, Het, HomRef, Het, Missing, HomAlt, Het, HomRef, HomAlt, Het])
     it "should correctly load genotype data with intersect" $ do
-        pacs <- mapM (readPoseidonPackage testPacReadOpts) pacFiles
+        pacs <- usePoseidonLogger NoLog $ mapM (readPoseidonPackage testPacReadOpts) pacFiles
         jointDat <- runSafeT $ do
-            (_, jointProd) <- getJointGenotypeData NoLog True pacs Nothing
+            (_, jointProd) <- getJointGenotypeData noLog True pacs Nothing
             P.toListM jointProd
         length jointDat `shouldBe` 8
         jointDat !! 3 `shouldBe` (EigenstratSnpEntry (Chrom "1") 949654 0.025727 "1_949654" 'A' 'G',
@@ -234,29 +234,29 @@ testGetJoinGenotypeData = describe "Poseidon.Package.getJointGenotypeData" $ do
                                                 HomAlt, Het, Het, HomAlt, Het, HomAlt, HomAlt, HomAlt, HomAlt, HomAlt])
         jointDat !! 4 `shouldBe` (EigenstratSnpEntry (Chrom "2") 1045331 0.026665 "2_1045331" 'G' 'A', V.fromList $ replicate 20 HomRef)
     it "should correctly load the right nr of SNPs with snpFile and no intersect" $ do
-        pacs <- mapM (readPoseidonPackage testPacReadOpts) pacFiles
+        pacs <- usePoseidonLogger NoLog $ mapM (readPoseidonPackage testPacReadOpts) pacFiles
         jointDat <- runSafeT $ do
-            (_, jointProd) <- getJointGenotypeData NoLog False pacs (Just "test/testDat/snpFile.snp")
+            (_, jointProd) <- getJointGenotypeData noLog False pacs (Just "test/testDat/snpFile.snp")
             P.toListM jointProd
         length jointDat `shouldBe` 6
     it "should correctly load the right nr of SNPs with snpFile and intersect" $ do
-        pacs <- mapM (readPoseidonPackage testPacReadOpts) pacFiles
+        pacs <- usePoseidonLogger NoLog $ mapM (readPoseidonPackage testPacReadOpts) pacFiles
         jointDat <- runSafeT $ do
-            (_, jointProd) <- getJointGenotypeData NoLog True pacs (Just "test/testDat/snpFile.snp")
+            (_, jointProd) <- getJointGenotypeData noLog True pacs (Just "test/testDat/snpFile.snp")
             P.toListM jointProd
         length jointDat `shouldBe` 4
     it "should fail with unordered SNP input file" $ do
-        pacs <- mapM (readPoseidonPackage testPacReadOpts) pacFiles
+        pacs <- usePoseidonLogger NoLog $ mapM (readPoseidonPackage testPacReadOpts) pacFiles
         let makeJointDat = runSafeT $ do
-                (_, jointProd) <- getJointGenotypeData NoLog False pacs (Just "test/testDat/snpFile_unordered.snp")
+                (_, jointProd) <- getJointGenotypeData noLog False pacs (Just "test/testDat/snpFile_unordered.snp")
                 P.toListM jointProd
         makeJointDat `shouldThrow` isInputOrderException
     it "should skip incongruent alleles" $ do
         let pacFiles2 = ["test/testDat/testPackages/ancient/Lamnidis_2018/POSEIDON.yml",
                          "test/testDat/testPackages/test_incongruent_snps/POSEIDON.yml"]
-        pacs <- mapM (readPoseidonPackage testPacReadOpts) pacFiles2
+        pacs <- usePoseidonLogger NoLog $ mapM (readPoseidonPackage testPacReadOpts) pacFiles2
         jointDat <- runSafeT $ do
-            (_, jointProd) <- getJointGenotypeData NoLog False pacs Nothing
+            (_, jointProd) <- getJointGenotypeData noLog False pacs Nothing
             P.toListM jointProd
         length jointDat `shouldBe` 7
 


### PR DESCRIPTION
My motivation for this PR is two-fold:
1) I wanted to clean up this hack of collecting the SNP-merging messages from inside the `SafeT` Pipe in a list before logging them. I think it obfuscates the code. I think if a function needs to log something, it simply needs to be able to do so, no matter where in the function call stack we are. Perhaps that's a bit up to taste... but given the emerged complexity of this project I jump at opportunities to simplify things.

2) I found it unsatisfactory that we already use a `ReaderT`-like system to pass Logging Actions, but are unable to pull this LogAction when entering the `SafeT pipe`, making this hack of passing `LogMode` from the top to the very bottom. 

The key change is a change of `PoseidonLogIO`. Before, we had used `LoggerT`, which is a wrapper around this:

```
ReaderT (LogAction (LoggerT Message IO) Message) IO
```

which looks scary, and it is. The tricky bit here is that because of this inner `LoggerT` type inside of `LogAction`, there is no way we can get out the action to perform logging inside IO. For example, we might want to say `logAction <- ask` inside of `PoseidonLogIO`, which is possible because of the `MonadReader` instance of `LoggerT`. This would be cool, because then we don't have to pass `LogMode` from the top, but can use `logAction` where we need it. 

_BUT_: The thing returned from `ask` is actually a `LogAction (LoggerT IO Message) Message IO`, which is extremely annoying and essentially forbids me to use this inside of `MonadIO`. 

I found a simple solution, which simply doesn't use `LoggerT`, but the much simpler:
```
type PoseidonLogIO = ReaderT (LogAction IO Message) IO
```

Note that the difference is the internal monad in `LogAction`, which is now `IO`, not `LoggerT Message IO`.

(Note that we actually define `type LogEnv = LogAction IO Message` in the code to make this even more readable)

Now, this works, but unfortunately it doesn't work with the existing `logDebug`, `logError` etc. functions from CoLog. Easy to fix, we just define our own, right in `Utils`... just 10 lines and we're done. So that's the "ugly" price to pay, but at least it's only ugly inside of `Utils`. All client code actually simplifies. First, I was able to sneak in `pack`, so we can now log Strings, getting rid of like a million or so `pack` calls. Second, as promised above, we can now use `ask` to retrieve the logging environment and pass it to client functions like `getJointGenotypeData` and further down. So I was able to remove `LogMode` from `ForgeOptions`.

I tried a quick forge and did not see any performance or memory leak.


