### PR TITLE
Server updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- V 1.1.3.0: Added new features to the server, updated logging, and new API for compatibility checks
 - V 1.1.2.0: Replaced progress indicators with simple, sequential log messages for the download in fetch and the SNP-wise operations in forge and genoconvert
 - V 1.1.1.3: Tiny change to make the documentation of --snpSet more clear
 - V 1.1.1.2: Outsourced optparse-applicative parsers to an own library module. This is helpful for xerxes and other derived tools/libraries

--- a/CHANGELOGRELEASE.md
+++ b/CHANGELOGRELEASE.md
@@ -2,6 +2,8 @@
 
 This release introduces a major change to the progress indicators in package downloading, reading, forging and converting. It also includes some minor code changes in the poseidon-hs library and the poseidon server executable.
 
+#### Trident 
+
 From a trident user perspective only the change in the progress indicators is relevant. So far we used updating (self-overwriting) counters, which were great for interactive use of trident in modern terminal emulators. They are not suitable for use in scripts, though, because the command line output does not yield well structured log files. We therefore decided to integrate the progress indicators with our general logging infrastructure.
 
 - Loading packages (so the `Initializing packages...` phase) now stays silent by default. With `--logMode VerboseLog` you can list the packages that are currently loading:
@@ -36,6 +38,14 @@ From a trident user perspective only the change in the progress indicators is re
 [Info]    MB:      3.2     20.9%
 [Info]    MB:      4.0     26.1%
 ```
+
+#### Server
+The server has been updated in the following ways:
+
+* It now uses Co-Log for logging
+* A new option -c now makes it ignore checksums, which is useful for a fast start of the server if need be
+* Zip files are now stored in a separate folder, to keep the (git-backed) repository itself clean
+* There is a new API named /compatibility/<version> which accepts a client version (from trident) and returns a JSON tuple of Haskell-type (Bool, Maybe String). The first element is simply a Boolean saying if the client version is compatible with the server or not, the second is an optional Warning message the server can return to the client. This will become important in the future.
 
 ### V 1.1.1.1
 

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -1,5 +1,5 @@
 name:                poseidon-hs
-version:             1.1.1.3
+version:             1.1.2.0
 synopsis:            A package with tools for working with Poseidon Genotype Data
 description:         The tools in this package read and analyse Poseidon-formatted genotype databases, a modular system for storing genotype data from thousands of individuals.
 license:             MIT

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -1,5 +1,5 @@
 name:                poseidon-hs
-version:             1.1.2.0
+version:             1.1.3.0
 synopsis:            A package with tools for working with Poseidon Genotype Data
 description:         The tools in this package read and analyse Poseidon-formatted genotype databases, a modular system for storing genotype data from thousands of individuals.
 license:             MIT

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -84,7 +84,7 @@ main = usePoseidonLogger VerboseLog $ do
             let compat = (True, Nothing) :: (Bool, Maybe String)
             _ <- case filter ((=="") . snd) $ readP_to_S parseVersion vStr of
                 [(v', "")] -> return v'
-                _         -> raise . pack $ "cannot parse Version nr " ++ vStr
+                _          -> raise . pack $ "cannot parse Version nr " ++ vStr
             json compat
 
         -- basic APIs for retreiving metadata

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -49,7 +49,7 @@ data CommandLineOptions = CommandLineOptions
     deriving (Show)
 
 main :: IO ()
-main = usePoseidonLogger ServerLog $ do
+main = usePoseidonLogger VerboseLog $ do
     logInfo "Server starting up. Loading packages..."
     CommandLineOptions baseDirs zipPath port ignoreGenoFiles ignoreChecksums certFiles <- liftIO $
         OP.customExecParser (OP.prefs OP.showHelpOnEmpty) optParserInfo

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -82,8 +82,8 @@ main = usePoseidonLogger VerboseLog $ do
         get "/compatibility/:client_version" $ do
             vStr <- param "client_version"
             let compat = (True, Nothing) :: (Bool, Maybe String)
-            v <- case filter ((=="") . snd) $ readP_to_S parseVersion vStr of
-                [(v, "")] -> return v
+            _ <- case filter ((=="") . snd) $ readP_to_S parseVersion vStr of
+                [(v', "")] -> return v'
                 _         -> raise . pack $ "cannot parse Version nr " ++ vStr
             json compat
 

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -9,8 +9,8 @@ import           Poseidon.Package            (PackageReadOptions (..),
 import           Poseidon.SecondaryTypes     (GroupInfo (..),
                                               IndividualInfo (..),
                                               PackageInfo (..))
-import           Poseidon.Utils              (LogMode (..), logInfo,
-                                              usePoseidonLogger, PoseidonLogIO)
+import           Poseidon.Utils              (LogMode (..), PoseidonLogIO,
+                                              logInfo, usePoseidonLogger)
 
 import           Codec.Archive.Zip           (Archive, addEntryToArchive,
                                               emptyArchive, fromArchive,
@@ -29,9 +29,9 @@ import           Network.Wai.Handler.WarpTLS (runTLS, tlsSettings,
 import           Network.Wai.Middleware.Cors (simpleCors)
 import qualified Options.Applicative         as OP
 import           Paths_poseidon_hs           (version)
-import           System.Directory            (doesFileExist,
-                                              getModificationTime,
-                                              createDirectoryIfMissing)
+import           System.Directory            (createDirectoryIfMissing,
+                                              doesFileExist,
+                                              getModificationTime)
 import           System.FilePath             ((<.>), (</>))
 import           Web.Scotty                  (ScottyM, file, get, html, json,
                                               middleware, notFound, param,

--- a/src-executables/Main-server.hs
+++ b/src-executables/Main-server.hs
@@ -71,7 +71,7 @@ main = usePoseidonLogger ServerLog $ do
             liftIO $ B.writeFile fn zip_raw
         return (posPacTitle pac, fn))
     let runScotty = case certFiles of
-            Nothing                  -> scottyHTTP port
+            Nothing                              -> scottyHTTP  port
             Just (certFile, chainFiles, keyFile) -> scottyHTTPS port certFile chainFiles keyFile
     runScotty $ do
         middleware simpleCors

--- a/src/Poseidon/GenotypeData.hs
+++ b/src/Poseidon/GenotypeData.hs
@@ -204,12 +204,12 @@ getConsensusSnpEntry logEnv snpEntries = do
             return selectedGenPos
     case uniqueAlleles of
         [] -> do -- no non-missing alleles found
-            logWithEnv logEnv . logDebug $
-                "SNP " ++ show id_ ++ " appears to have no data (both ref and alt allele are blank"
+            -- logWithEnv logEnv . logDebug $
+            --     "SNP " ++ show id_ ++ " appears to have no data (both ref and alt allele are blank"
             return (EigenstratSnpEntry chrom pos genPos id_ 'N' 'N')
         [r] -> do -- only one non-missing allele found
-            logWithEnv logEnv . logDebug $
-                "SNP " ++ show id_ ++ " appears to be monomorphic (only one of ref and alt alleles are non-blank)"
+            -- logWithEnv logEnv . logDebug $
+            --     "SNP " ++ show id_ ++ " appears to be monomorphic (only one of ref and alt alleles are non-blank)"
             return (EigenstratSnpEntry chrom pos genPos id_ 'N' r)
         [ref, alt] ->
             return (EigenstratSnpEntry chrom pos genPos id_ ref alt)


### PR DESCRIPTION
I have updated the server in multiple ways:
1) It now uses Co-Log for logging
2) A new option `-c` now makes it ignore checksums, which is useful for a fast start of the server if need be
3) Zip files are now stored in a separate folder, to keep the (git-backed) repository itself clean
4) There is a new API named `/compatibility/<version>` which accepts a client version (from trident) and returns a JSON tuple of Haskell-type (Bool, Maybe String). The first element is simply a Boolean saying if the client version is compatible with the server or not, the second is an optional Warning message the server can return to the client. 

Currently I don't make much use of the new API, but I would like to establish it in time to be able to later get away with a) breaking API changes and b) even more severe - a move of the server to a new URL. The latter will likely happen at some point, as I consider the current Cloud-Server to be temporary and the URL poor to remember. I'd like to switch to something like `www.poseidon-adna.de/server` or so. Anyway, this new API gives us a way of implementing a message-system within `trident` to be able to give early warnings to Clients if the Server intends to introduce breaking changes or a move.

I don't think a Code review is required here, since this PR affects only the server program so far. But of course, if there are objections to the new API, bring it on.