### PR TITLE
fixed --no-extract and made it capable to handle non-package entities correctly

### DIFF
--- a/src/Poseidon/CLI/Forge.hs
+++ b/src/Poseidon/CLI/Forge.hs
@@ -126,8 +126,14 @@ runForge (
     -- get all individuals from the relevant packages
     let allInds = getJointIndividualInfo $ relevantPackages
 
+    -- set entities to only packages, if --no-extract is set
+    let relevantEntities =
+            if noExtract
+            then map (Include . Pac . posPacTitle) relevantPackages
+            else entities
+
     -- determine indizes of relevant individuals and resolve duplicates
-    let (unresolvedDuplicatedInds, relevantIndices) = resolveEntityIndices entities allInds
+    let (unresolvedDuplicatedInds, relevantIndices) = resolveEntityIndices relevantEntities allInds
 
     -- check if there still are duplicates and if yes, then stop
     unless (null unresolvedDuplicatedInds) $ do
@@ -185,8 +191,7 @@ runForge (
     newNrSNPs <- liftIO $ catch (
         runSafeT $ do
             (eigenstratIndEntries, eigenstratProd) <- getJointGenotypeData logEnv intersect_ relevantPackages maybeSnpFile
-            let eigenstratIndEntriesV = eigenstratIndEntries
-            let newEigenstratIndEntries = map (eigenstratIndEntriesV !!) relevantIndices
+            let newEigenstratIndEntries = map (eigenstratIndEntries !!) relevantIndices
 
             let [outG, outS, outI] = map (outPath </>) [outGeno, outSnp, outInd]
             let outConsumer = case outFormat of


### PR DESCRIPTION
I think this should solve #185. It's a very minimal change, actually, but I think this is sufficient. This PR is on top of #212. Maybe not the best idea, but I wanted to combine these bug-fixes in one big release.

I was about to write some tests for `--no-extract`, but then I thought I should first test how big the performance increase actually is. A simple test case with 

```
trident forge -d . -f "*2010_RasmussenNature*,*2012_MeyerScience*" -o huhu --no-extract

trident forge -d . -f "*2010_RasmussenNature*,*2012_MeyerScience*" -o huhu
```

showed no relevant difference at all, though:
```
real	0m41,138s
user	0m40,871s
sys	0m0,264s

real	0m41,401s
user	0m41,198s
sys	0m0,201s
```

Do you have a test case where `--no-extract` actually has an advantage, @stschiff? Or was this option only based on the assumption that it *could* be faster? Then I would suggest to deprecate it right away.

The help for `--no-extract` is also a bit misleading:

```
Skip the selection step in forge. This will result in
outputting all individuals in the relevant packages,
and hence a superset of the requested
individuals/groups. It may result in better
performance in cases where one wants to forge entire
packages or almost entire packages. Note that this
will also ignore any ordering in the output
groups/individuals. With this option active,
individuals from the relevant packages will just be
written in the order that they appear in the original
packages.
```

Afaik the individuals in the output files are ALWAYS ordered according to the order in the packages (and the packages in order of their detection by the .yml file detection). Maybe that's something we want to change one day, but it's not entirely clear, what the order should be, given the logic of our query language.