### PR TITLE
added a proper warning if one or all baseDirs do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- V 1.1.7.2: Added a proper warning in `readPoseidonPackageCollection` if one or all baseDirs do not exist 
 - V 1.1.7.1: Added a hint about `--logMode VerboseLog` to the important "Broken lines" error message in the .janno reading process
 - V 1.1.7.0: Reorganized handling of duplicate individuals: Duplicates are now generally ignored, except in validate (can also be turned of with a new flag) and forge. The forgeString language features a new syntactic entity to select individuals specifically and thus resolve duplication conflicts
 - V 1.1.6.0: Removed outdated --verbose from validate and ignore trailing slashes from --outPath

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -1,5 +1,5 @@
 name:                poseidon-hs
-version:             1.1.7.1
+version:             1.1.7.2
 synopsis:            A package with tools for working with Poseidon Genotype Data
 description:         The tools in this package read and analyse Poseidon-formatted genotype databases, a modular system for storing genotype data from thousands of individuals.
 license:             MIT

--- a/src/Poseidon/CLI/Validate.hs
+++ b/src/Poseidon/CLI/Validate.hs
@@ -32,10 +32,10 @@ pacReadOpts = defaultPackageReadOptions {
 
 runValidate :: ValidateOptions -> PoseidonLogIO ()
 runValidate (ValidateOptions baseDirs ignoreGeno noExitCode ignoreDup) = do
-    posFiles <- liftIO $ concat <$> mapM findAllPoseidonYmlFiles baseDirs
     allPackages <- readPoseidonPackageCollection
         pacReadOpts {_readOptIgnoreGeno = ignoreGeno, _readOptStopOnDuplicates = not ignoreDup}
         baseDirs
+    posFiles <- liftIO $ concat <$> mapM findAllPoseidonYmlFiles baseDirs
     let numberOfPOSEIDONymlFiles = length posFiles
         numberOfLoadedPackagesWithDuplicates = foldl' (+) 0 $ map posPacDuplicate allPackages
     if numberOfPOSEIDONymlFiles == numberOfLoadedPackagesWithDuplicates

--- a/src/Poseidon/CLI/Validate.hs
+++ b/src/Poseidon/CLI/Validate.hs
@@ -12,7 +12,9 @@ import           Poseidon.Utils         (PoseidonLogIO, logError, logInfo)
 
 import           Control.Monad          (unless)
 import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.List     (filterM)
 import           Data.List              (foldl')
+import           System.Directory       (doesDirectoryExist)
 import           System.Exit            (exitFailure, exitSuccess)
 
 
@@ -35,7 +37,8 @@ runValidate (ValidateOptions baseDirs ignoreGeno noExitCode ignoreDup) = do
     allPackages <- readPoseidonPackageCollection
         pacReadOpts {_readOptIgnoreGeno = ignoreGeno, _readOptStopOnDuplicates = not ignoreDup}
         baseDirs
-    posFiles <- liftIO $ concat <$> mapM findAllPoseidonYmlFiles baseDirs
+    goodDirs <- liftIO $ filterM doesDirectoryExist baseDirs
+    posFiles <- liftIO $ concat <$> mapM findAllPoseidonYmlFiles goodDirs
     let numberOfPOSEIDONymlFiles = length posFiles
         numberOfLoadedPackagesWithDuplicates = foldl' (+) 0 $ map posPacDuplicate allPackages
     if numberOfPOSEIDONymlFiles == numberOfLoadedPackagesWithDuplicates

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -278,7 +278,7 @@ readPoseidonPackageCollection opts baseDirs = do
         if exists
         then return (Just p)
         else do
-            logWarning $ "baseDir " ++ show p ++ " does not exist"
+            logWarning $ "Base directory (-d) " ++ show p ++ " does not exist"
             return Nothing
     filterByPoseidonVersion :: [FilePath] -> PoseidonLogIO [FilePath]
     filterByPoseidonVersion posFiles = do

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -236,7 +236,6 @@ readPoseidonPackageCollection :: PackageReadOptions
 readPoseidonPackageCollection opts baseDirs = do
     logInfo "Checking base directories... "
     goodDirs <- catMaybes <$> mapM checkIfBaseDirExists baseDirs
-    when (null goodDirs) $ liftIO $ throwIO PoseidonNoExistingBaseDirs
     logInfo "Searching POSEIDON.yml files... "
     posFilesAllVersions <- liftIO $ concat <$> mapM findAllPoseidonYmlFiles goodDirs
     logInfo $ show (length posFilesAllVersions) ++ " found"

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -60,6 +60,7 @@ usePoseidonLogger VerboseLog = flip runReaderT verboseLog
 
 testLog :: PoseidonLogIO a -> IO a
 testLog = usePoseidonLogger NoLog
+--testLog = usePoseidonLogger DefaultLog
 
 noLog      :: LogEnv
 noLog      = cfilter (const False) simpleLog
@@ -116,8 +117,7 @@ logWithEnv logEnv = liftIO . flip runReaderT logEnv
 
 -- | A Poseidon Exception data type with several concrete constructors
 data PoseidonException =
-      PoseidonNoExistingBaseDirs -- ^ An exception to indicate that non of the listed baseDirs exists
-    | PoseidonYamlParseException FilePath ParseException -- ^ An exception to represent YAML parsing errors
+      PoseidonYamlParseException FilePath ParseException -- ^ An exception to represent YAML parsing errors
     | PoseidonPackageException String -- ^ An exception to represent a logical error in a package
     | PoseidonPackageVersionException FilePath String -- ^ An exception to represent an issue with a package version
     | PoseidonPackageMissingVersionException FilePath -- ^ An exception to indicate a missing poseidonVersion field
@@ -145,8 +145,6 @@ data PoseidonException =
 instance Exception PoseidonException
 
 renderPoseidonException :: PoseidonException -> String
-renderPoseidonException PoseidonNoExistingBaseDirs =
-    "None of the listed base dirs exist"
 renderPoseidonException (PoseidonYamlParseException fn e) =
     "Could not parse YAML file " ++ fn ++ ": " ++ show e
 renderPoseidonException (PoseidonPackageException s) =

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -116,7 +116,8 @@ logWithEnv logEnv = liftIO . flip runReaderT logEnv
 
 -- | A Poseidon Exception data type with several concrete constructors
 data PoseidonException =
-    PoseidonYamlParseException FilePath ParseException -- ^ An exception to represent YAML parsing errors
+      PoseidonNoExistingBaseDirs -- ^ An exception to indicate that non of the listed baseDirs exists
+    | PoseidonYamlParseException FilePath ParseException -- ^ An exception to represent YAML parsing errors
     | PoseidonPackageException String -- ^ An exception to represent a logical error in a package
     | PoseidonPackageVersionException FilePath String -- ^ An exception to represent an issue with a package version
     | PoseidonPackageMissingVersionException FilePath -- ^ An exception to indicate a missing poseidonVersion field
@@ -144,6 +145,8 @@ data PoseidonException =
 instance Exception PoseidonException
 
 renderPoseidonException :: PoseidonException -> String
+renderPoseidonException PoseidonNoExistingBaseDirs =
+    "None of the listed base dirs exist"
 renderPoseidonException (PoseidonYamlParseException fn e) =
     "Could not parse YAML file " ++ fn ++ ": " ++ show e
 renderPoseidonException (PoseidonPackageException s) =

--- a/test/testDat/poseidonHSGoldenTestData/ForgePac7/POSEIDON.yml
+++ b/test/testDat/poseidonHSGoldenTestData/ForgePac7/POSEIDON.yml
@@ -6,7 +6,7 @@ contributor:
   email: carberry@brown.edu
   orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
-lastModified: 2023-01-12
+lastModified: 2023-01-24
 genotypeData:
   format: EIGENSTRAT
   genoFile: ForgePac7.geno


### PR DESCRIPTION
```
trident: gz: getDirectoryContents:openDirStream: does not exist (No such file or directory)
```

is now

```
[Info]    Checking base directories...
[Warning] Base directory (-d) "gz" does not exist
```