### PR TITLE
Janno input validation for JSON and CSV data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- V 1.1.8.4: Unified the implementation of ToJSON/FromJSON and ToField/FromField instances for .janno datatypes to perform input validation through smart constructors
 - V 1.1.8.3: The fix in introduced in 1.1.8.1 introduced a bug: It broke valid unicode characters in .janno files and prevented reading them. The solution implemented here solves this issue
 - V 1.1.8.2: Improved the behaviour of `list` when provided with undefined .janno columns in the `-j` argument
 - V 1.1.8.1: Fixed an decoding-encoding bug in the janno code by generally trimming all whitespaces on reading and deleting No-Break Space characters

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -56,7 +56,7 @@ Test-Suite poseidon-tools-tests
                         raw-strings-qq, yaml, time, vector,
                         text, QuickCheck, directory, sequence-formats,
                         filepath, pipes, pipes-safe, pipes-ordered-zip,
-                        unordered-containers
+                        unordered-containers, cassava
     other-modules:      Poseidon.PackageSpec, Poseidon.JannoSpec,
                         Poseidon.BibFileSpec, Poseidon.MathHelpersSpec,
                         Poseidon.SummariseSpec, Poseidon.SurveySpec, Poseidon.GenotypeDataSpec,

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -1,5 +1,5 @@
 name:                poseidon-hs
-version:             1.1.8.3
+version:             1.1.8.4
 synopsis:            A package with tools for working with Poseidon Genotype Data
 description:         The tools in this package read and analyse Poseidon-formatted genotype databases, a modular system for storing genotype data from thousands of individuals.
 license:             MIT

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -28,7 +28,8 @@ library
                         vector, pipes-ordered-zip, table-layout, mtl,
                         cassava, pureMD5,
                         yaml-pretty-extras, http-conduit, conduit, http-types, zip-archive,
-                        unordered-containers, network-uri, optparse-applicative, co-log, regex-tdfa
+                        unordered-containers, network-uri, optparse-applicative, co-log, regex-tdfa,
+                        scientific
     default-language:   Haskell2010
 
 executable trident

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -42,7 +42,10 @@ import           Data.Aeson                           (FromJSON, Options (..),
                                                        defaultOptions,
                                                        genericToEncoding,
                                                        parseJSON, toEncoding,
-                                                       toJSON, withObject, (.:), withText, withScientific)
+                                                       toJSON, withObject,
+                                                       withScientific, withText,
+                                                       (.:))
+import           Data.Aeson.Encoding                  (text)
 import           Data.Aeson.Types                     (emptyObject)
 import           Data.Bifunctor                       (second)
 import qualified Data.ByteString.Char8                as Bchs
@@ -55,7 +58,9 @@ import           Data.List                            (elemIndex, foldl',
                                                        intercalate, nub, sort,
                                                        (\\))
 import           Data.Maybe                           (fromJust, isNothing)
+import           Data.Scientific                      (toBoundedInteger)
 import           Data.Text                            (pack, replace, unpack)
+import qualified Data.Text                            as T
 import qualified Data.Vector                          as V
 import           GHC.Generics                         (Generic)
 import           Network.URI                          (isURI)
@@ -63,9 +68,6 @@ import           Options.Applicative.Help.Levenshtein (editDistance)
 import           SequenceFormats.Eigenstrat           (EigenstratIndEntry (..),
                                                        Sex (..))
 import qualified Text.Regex.TDFA                      as Reg
-import qualified Data.Text as T
-import Data.Scientific (toBoundedInteger)
-import Data.Aeson.Encoding (text)
 
 -- | A datatype for genetic sex
 newtype JannoSex = JannoSex { sfSex :: Sex }
@@ -118,7 +120,7 @@ makeBCADAge x =
       else pure (BCADAge x)
 
 instance FromJSON BCADAge where
-    parseJSON = withScientific "BCADAge" $ \n -> 
+    parseJSON = withScientific "BCADAge" $ \n ->
         case toBoundedInteger n of
             Nothing -> fail $ "Number" ++ show n ++ "doesn't fit into a bounded integer."
             Just x -> makeBCADAge x

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -94,16 +94,10 @@ makeJannoSex x
 
 instance FromJSON JannoSex where
     parseJSON = withText "JannoSex" (makeJannoSex . T.unpack)
-
 instance Csv.FromField JannoSex where
     parseField x = Csv.parseField x >>= makeJannoSex
-
 instance ToJSON JannoSex where
-    -- this encodes directly to a bytestring Builder
-    toJSON (JannoSex Female)  = String "F"
-    toJSON (JannoSex Male)    = String "M"
-    toJSON (JannoSex Unknown) = String "U"
-
+    toJSON x  = String $ T.pack $ show x
 instance Csv.ToField JannoSex where
     toField x = Csv.toField $ show x
 
@@ -128,13 +122,10 @@ instance FromJSON BCADAge where
         case toBoundedInteger n of
             Nothing -> fail $ "Number" ++ show n ++ "doesn't fit into a bounded integer."
             Just x -> makeBCADAge x
-
 instance Csv.FromField BCADAge where
     parseField x = Csv.parseField x >>= makeBCADAge
-
 instance ToJSON BCADAge where
     toEncoding = genericToEncoding defaultOptions
-
 instance Csv.ToField BCADAge where
     toField (BCADAge x) = Csv.toField x
 
@@ -159,13 +150,10 @@ makeJannoDateType x
 
 instance FromJSON JannoDateType where
     parseJSON = withText "JannoDateType" (makeJannoDateType . T.unpack)
-
 instance Csv.FromField JannoDateType where
     parseField x = Csv.parseField x >>= makeJannoDateType
-
 instance ToJSON JannoDateType where
     toEncoding x = text $ T.pack $ show x
-
 instance Csv.ToField JannoDateType where
     toField x = Csv.toField $ show x
 
@@ -206,13 +194,10 @@ makeJannoCaptureType x
 
 instance FromJSON JannoCaptureType where
     parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
-
 instance Csv.FromField JannoCaptureType where
     parseField x = Csv.parseField x >>= makeJannoCaptureType
-
 instance ToJSON JannoCaptureType where
     toEncoding x = text $ T.pack $ show x
-
 instance Csv.ToField JannoCaptureType where
     toField x = Csv.toField $ show x
 
@@ -234,17 +219,12 @@ makeJannoGenotypePloidy x
 
 instance FromJSON JannoGenotypePloidy where
     parseJSON = withText "JannoGenotypePloidy" (makeJannoGenotypePloidy . T.unpack)
-
 instance Csv.FromField JannoGenotypePloidy where
     parseField x = Csv.parseField x >>= makeJannoGenotypePloidy
-
 instance ToJSON JannoGenotypePloidy where
-    toEncoding Diploid = text "diploid"
-    toEncoding Haploid = text "haploid"
-
+    toEncoding x = text $ T.pack $ show x
 instance Csv.ToField JannoGenotypePloidy where
-    toField Diploid = "diploid"
-    toField Haploid = "haploid"
+    toField x = Csv.toField $ show x
 
 -- |A datatype to represent UDG in a janno file
 data JannoUDG = Minus

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -119,17 +119,17 @@ makeBCADAge x =
                    "Did you accidentally enter a BP date?"
       else pure (BCADAge x)
 
+instance Csv.FromField BCADAge where
+    parseField x = Csv.parseField x >>= makeBCADAge
+instance Csv.ToField BCADAge where
+    toField (BCADAge x) = Csv.toField x
 instance FromJSON BCADAge where
     parseJSON = withScientific "BCADAge" $ \n ->
         case toBoundedInteger n of
             Nothing -> fail $ "Number" ++ show n ++ "doesn't fit into a bounded integer."
             Just x -> makeBCADAge x
-instance Csv.FromField BCADAge where
-    parseField x = Csv.parseField x >>= makeBCADAge
 instance ToJSON BCADAge where
     toEncoding = genericToEncoding defaultOptions
-instance Csv.ToField BCADAge where
-    toField (BCADAge x) = Csv.toField x
 
 -- |A datatype to represent Date_Type in a janno file
 data JannoDateType =
@@ -150,14 +150,14 @@ makeJannoDateType x
     | x == "modern"     = pure Modern
     | otherwise         = fail $ "Date_Type " ++ show x ++ " not in [C14, contextual, modern]"
 
-instance FromJSON JannoDateType where
-    parseJSON = withText "JannoDateType" (makeJannoDateType . T.unpack)
 instance Csv.FromField JannoDateType where
     parseField x = Csv.parseField x >>= makeJannoDateType
-instance ToJSON JannoDateType where
-    toEncoding x = text $ T.pack $ show x
 instance Csv.ToField JannoDateType where
     toField x = Csv.toField $ show x
+instance FromJSON JannoDateType where
+    parseJSON = withText "JannoDateType" (makeJannoDateType . T.unpack)
+instance ToJSON JannoDateType where
+    toEncoding x = text $ T.pack $ show x
 
 -- |A datatype to represent Capture_Type in a janno file
 data JannoCaptureType =
@@ -194,14 +194,14 @@ makeJannoCaptureType x
     | otherwise                 = fail $ "Capture_Type " ++ show x ++
                                       " not in [Shotgun, 1240K, ArborComplete, ArborPrimePlus, ArborAncestralPlus, TwistAncientDNA, OtherCapture, ReferenceGenome]"
 
-instance FromJSON JannoCaptureType where
-    parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
 instance Csv.FromField JannoCaptureType where
     parseField x = Csv.parseField x >>= makeJannoCaptureType
-instance ToJSON JannoCaptureType where
-    toEncoding x = text $ T.pack $ show x
 instance Csv.ToField JannoCaptureType where
     toField x = Csv.toField $ show x
+instance FromJSON JannoCaptureType where
+    parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
+instance ToJSON JannoCaptureType where
+    toEncoding x = text $ T.pack $ show x
 
 -- |A datatype to represent Genotype_Ploidy in a janno file
 data JannoGenotypePloidy =
@@ -219,14 +219,14 @@ makeJannoGenotypePloidy x
     | x == "haploid" = pure Haploid
     | otherwise      = fail $ "Genotype_Ploidy " ++ show x ++ " not in [diploid, haploid]"
 
-instance FromJSON JannoGenotypePloidy where
-    parseJSON = withText "JannoGenotypePloidy" (makeJannoGenotypePloidy . T.unpack)
 instance Csv.FromField JannoGenotypePloidy where
     parseField x = Csv.parseField x >>= makeJannoGenotypePloidy
-instance ToJSON JannoGenotypePloidy where
-    toEncoding x = text $ T.pack $ show x
 instance Csv.ToField JannoGenotypePloidy where
     toField x = Csv.toField $ show x
+instance FromJSON JannoGenotypePloidy where
+    parseJSON = withText "JannoGenotypePloidy" (makeJannoGenotypePloidy . T.unpack)
+instance ToJSON JannoGenotypePloidy where
+    toEncoding x = text $ T.pack $ show x
 
 -- |A datatype to represent UDG in a janno file
 data JannoUDG = Minus

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -19,6 +19,7 @@ module Poseidon.Janno (
     JURI (..),
     RelationDegree (..),
     JannoLibraryBuilt (..),
+    AccessionID (..),
     writeJannoFile,
     readJannoFile,
     concatJannos,
@@ -135,7 +136,7 @@ data JannoDateType =
       C14
     | Contextual
     | Modern
-    deriving (Eq, Ord, Generic)
+    deriving (Eq, Ord, Generic, Enum, Bounded)
 
 instance Show JannoDateType where
     show C14        = "C14"
@@ -168,7 +169,7 @@ data JannoCaptureType =
     | TwistAncientDNA
     | OtherCapture
     | ReferenceGenome
-    deriving (Eq, Ord, Generic)
+    deriving (Eq, Ord, Generic, Enum, Bounded)
 
 instance Show JannoCaptureType where
     show Shotgun            = "Shotgun"
@@ -202,12 +203,11 @@ instance ToJSON JannoCaptureType where
 instance FromJSON JannoCaptureType where
     parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
 
-
 -- |A datatype to represent Genotype_Ploidy in a janno file
 data JannoGenotypePloidy =
       Diploid
     | Haploid
-    deriving (Eq, Ord, Generic)
+    deriving (Eq, Ord, Generic, Enum, Bounded)
 
 instance Show JannoGenotypePloidy where
     show Diploid = "diploid"
@@ -234,7 +234,7 @@ data JannoUDG =
     | Half
     | Plus
     | Mixed
-    deriving (Eq, Ord, Generic)
+    deriving (Eq, Ord, Generic, Enum, Bounded)
 
 instance Show JannoUDG where
     show Minus = "minus"
@@ -264,7 +264,7 @@ data JannoLibraryBuilt =
       DS
     | SS
     | Other
-    deriving (Eq, Ord, Generic)
+    deriving (Eq, Ord, Generic, Enum, Bounded)
 
 instance Show JannoLibraryBuilt where
     show DS    = "ds"
@@ -386,7 +386,7 @@ data RelationDegree =
     | SixthToTenth
     | Unrelated
     | OtherDegree
-    deriving (Eq, Ord, Generic)
+    deriving (Eq, Ord, Generic, Enum, Bounded)
 
 instance Show RelationDegree where
     show Identical    = "identical"

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -93,14 +93,14 @@ makeJannoSex x
     | x == "U"  = pure (JannoSex Unknown)
     | otherwise = fail $ "Sex " ++ show x ++ " not in [F, M, U]"
 
-instance Csv.FromField JannoSex where
-    parseField x = Csv.parseField x >>= makeJannoSex
 instance Csv.ToField JannoSex where
     toField x = Csv.toField $ show x
-instance FromJSON JannoSex where
-    parseJSON = withText "JannoSex" (makeJannoSex . T.unpack)
+instance Csv.FromField JannoSex where
+    parseField x = Csv.parseField x >>= makeJannoSex
 instance ToJSON JannoSex where
     toJSON x  = String $ T.pack $ show x
+instance FromJSON JannoSex where
+    parseJSON = withText "JannoSex" (makeJannoSex . T.unpack)
 
 -- | A datatype for BC-AD ages
 newtype BCADAge =
@@ -118,17 +118,17 @@ makeBCADAge x =
                    "Did you accidentally enter a BP date?"
       else pure (BCADAge x)
 
-instance Csv.FromField BCADAge where
-    parseField x = Csv.parseField x >>= makeBCADAge
 instance Csv.ToField BCADAge where
     toField (BCADAge x) = Csv.toField x
+instance Csv.FromField BCADAge where
+    parseField x = Csv.parseField x >>= makeBCADAge
+instance ToJSON BCADAge where
+    toEncoding = genericToEncoding defaultOptions
 instance FromJSON BCADAge where
     parseJSON = withScientific "BCADAge" $ \n ->
         case toBoundedInteger n of
             Nothing -> fail $ "Number" ++ show n ++ "doesn't fit into a bounded integer."
             Just x -> makeBCADAge x
-instance ToJSON BCADAge where
-    toEncoding = genericToEncoding defaultOptions
 
 -- |A datatype to represent Date_Type in a janno file
 data JannoDateType =
@@ -149,14 +149,14 @@ makeJannoDateType x
     | x == "modern"     = pure Modern
     | otherwise         = fail $ "Date_Type " ++ show x ++ " not in [C14, contextual, modern]"
 
-instance Csv.FromField JannoDateType where
-    parseField x = Csv.parseField x >>= makeJannoDateType
 instance Csv.ToField JannoDateType where
     toField x = Csv.toField $ show x
-instance FromJSON JannoDateType where
-    parseJSON = withText "JannoDateType" (makeJannoDateType . T.unpack)
+instance Csv.FromField JannoDateType where
+    parseField x = Csv.parseField x >>= makeJannoDateType
 instance ToJSON JannoDateType where
     toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoDateType where
+    parseJSON = withText "JannoDateType" (makeJannoDateType . T.unpack)
 
 -- |A datatype to represent Capture_Type in a janno file
 data JannoCaptureType =
@@ -193,14 +193,15 @@ makeJannoCaptureType x
     | otherwise                 = fail $ "Capture_Type " ++ show x ++
                                       " not in [Shotgun, 1240K, ArborComplete, ArborPrimePlus, ArborAncestralPlus, TwistAncientDNA, OtherCapture, ReferenceGenome]"
 
-instance Csv.FromField JannoCaptureType where
-    parseField x = Csv.parseField x >>= makeJannoCaptureType
 instance Csv.ToField JannoCaptureType where
     toField x = Csv.toField $ show x
-instance FromJSON JannoCaptureType where
-    parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
+instance Csv.FromField JannoCaptureType where
+    parseField x = Csv.parseField x >>= makeJannoCaptureType
 instance ToJSON JannoCaptureType where
     toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoCaptureType where
+    parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
+
 
 -- |A datatype to represent Genotype_Ploidy in a janno file
 data JannoGenotypePloidy =
@@ -218,14 +219,14 @@ makeJannoGenotypePloidy x
     | x == "haploid" = pure Haploid
     | otherwise      = fail $ "Genotype_Ploidy " ++ show x ++ " not in [diploid, haploid]"
 
-instance Csv.FromField JannoGenotypePloidy where
-    parseField x = Csv.parseField x >>= makeJannoGenotypePloidy
 instance Csv.ToField JannoGenotypePloidy where
     toField x = Csv.toField $ show x
-instance FromJSON JannoGenotypePloidy where
-    parseJSON = withText "JannoGenotypePloidy" (makeJannoGenotypePloidy . T.unpack)
+instance Csv.FromField JannoGenotypePloidy where
+    parseField x = Csv.parseField x >>= makeJannoGenotypePloidy
 instance ToJSON JannoGenotypePloidy where
     toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoGenotypePloidy where
+    parseJSON = withText "JannoGenotypePloidy" (makeJannoGenotypePloidy . T.unpack)
 
 -- |A datatype to represent UDG in a janno file
 data JannoUDG =
@@ -249,14 +250,14 @@ makeJannoUDG x
     | x == "mixed" = pure Mixed
     | otherwise    = fail $ "UDG " ++ show x ++ " not in [minus, half, plus, mixed]"
 
-instance Csv.FromField JannoUDG where
-    parseField x = Csv.parseField x >>= makeJannoUDG
 instance Csv.ToField JannoUDG where
     toField x = Csv.toField $ show x
-instance FromJSON JannoUDG where
-    parseJSON = withText "JannoUDG" (makeJannoUDG . T.unpack)
+instance Csv.FromField JannoUDG where
+    parseField x = Csv.parseField x >>= makeJannoUDG
 instance ToJSON JannoUDG where
     toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoUDG where
+    parseJSON = withText "JannoUDG" (makeJannoUDG . T.unpack)
 
 -- |A datatype to represent Library_Built in a janno file
 data JannoLibraryBuilt =
@@ -277,14 +278,14 @@ makeJannoLibraryBuilt x
     | x == "other" = pure Other
     | otherwise    = fail $ "Library_Built " ++ show x ++ " not in [ds, ss, other]"
 
-instance Csv.FromField JannoLibraryBuilt where
-    parseField x = Csv.parseField x >>= makeJannoLibraryBuilt
 instance Csv.ToField JannoLibraryBuilt where
     toField x = Csv.toField $ show x
-instance FromJSON JannoLibraryBuilt where
-    parseJSON = withText "JannoLibraryBuilt" (makeJannoLibraryBuilt . T.unpack)
+instance Csv.FromField JannoLibraryBuilt where
+    parseField x = Csv.parseField x >>= makeJannoLibraryBuilt
 instance ToJSON JannoLibraryBuilt where
     toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoLibraryBuilt where
+    parseJSON = withText "JannoLibraryBuilt" (makeJannoLibraryBuilt . T.unpack)
 
 -- | A datatype for Latitudes
 newtype Latitude =
@@ -299,14 +300,14 @@ makeLatitude x
     | x >= -90 && x <= 90 = pure (Latitude x)
     | otherwise           = fail $ "Latitude " ++ show x ++ " not between -90 and 90"
 
-instance Csv.FromField Latitude where
-    parseField x = Csv.parseField x >>= makeLatitude
 instance Csv.ToField Latitude where
     toField (Latitude x) = Csv.toField x
-instance FromJSON Latitude where
-    parseJSON = withScientific "Latitude" $ \n -> (makeLatitude . toRealFloat) n
+instance Csv.FromField Latitude where
+    parseField x = Csv.parseField x >>= makeLatitude
 instance ToJSON Latitude where
     toEncoding = genericToEncoding defaultOptions
+instance FromJSON Latitude where
+    parseJSON = withScientific "Latitude" $ \n -> (makeLatitude . toRealFloat) n
 
 -- | A datatype for Longitudes
 newtype Longitude =
@@ -321,14 +322,14 @@ makeLongitude x
     | x >= -180 && x <= 180 = pure (Longitude x)
     | otherwise             = fail $ "Longitude " ++ show x ++ " not between -180 and 180"
 
-instance Csv.FromField Longitude where
-    parseField x = Csv.parseField x >>= makeLongitude
 instance Csv.ToField Longitude where
     toField (Longitude x) = Csv.toField x
-instance FromJSON Longitude where
-    parseJSON = withScientific "Longitude" $ \n -> (makeLongitude . toRealFloat) n
+instance Csv.FromField Longitude where
+    parseField x = Csv.parseField x >>= makeLongitude
 instance ToJSON Longitude where
     toEncoding = genericToEncoding defaultOptions
+instance FromJSON Longitude where
+    parseJSON = withScientific "Longitude" $ \n -> (makeLongitude . toRealFloat) n
 
 -- | A datatype for Percent values
 newtype Percent =
@@ -343,14 +344,14 @@ makePercent x
     | x >= 0 && x <= 100 = pure (Percent x)
     | otherwise          = fail $ "Percentage " ++ show x ++ " not between 0 and 100"
 
-instance Csv.FromField Percent where
-    parseField x = Csv.parseField x >>= makePercent
 instance Csv.ToField Percent where
     toField (Percent x) = Csv.toField x
-instance FromJSON Percent where
-    parseJSON = withScientific "Percent" $ \n -> (makePercent . toRealFloat) n
+instance Csv.FromField Percent where
+    parseField x = Csv.parseField x >>= makePercent
 instance ToJSON Percent where
     toEncoding = genericToEncoding defaultOptions
+instance FromJSON Percent where
+    parseJSON = withScientific "Percent" $ \n -> (makePercent . toRealFloat) n
 
 -- | A datatype to represent URIs in a janno file
 newtype JURI =
@@ -365,14 +366,14 @@ makeJURI x
     | isURI x   = pure $ JURI x
     | otherwise = fail $ "URI " ++ show x ++ " not well structured"
 
-instance Csv.FromField JURI where
-    parseField x = Csv.parseField x >>= makeJURI
 instance Csv.ToField JURI where
     toField x = Csv.toField $ show x
-instance FromJSON JURI where
-    parseJSON = withText "JURI" (makeJURI . T.unpack)
+instance Csv.FromField JURI where
+    parseField x = Csv.parseField x >>= makeJURI
 instance ToJSON JURI where
     toEncoding x = text $ T.pack $ show x
+instance FromJSON JURI where
+    parseJSON = withText "JURI" (makeJURI . T.unpack)
 
 -- |A datatype to represent Relationship degree lists in a janno file
 type JannoRelationDegreeList = JannoList RelationDegree
@@ -410,14 +411,14 @@ makeRelationDegree x
     | otherwise           = fail $ "Relation degree " ++ show x ++
                                    " not in [identical, first, second, thirdToFifth, sixthToTenth, other]"
 
-instance Csv.FromField RelationDegree where
-    parseField x = Csv.parseField x >>= makeRelationDegree
 instance Csv.ToField RelationDegree where
     toField x = Csv.toField $ show x
-instance FromJSON RelationDegree where
-    parseJSON = withText "RelationDegree" (makeRelationDegree . T.unpack)
+instance Csv.FromField RelationDegree where
+    parseField x = Csv.parseField x >>= makeRelationDegree
 instance ToJSON RelationDegree where
     toEncoding x = text $ T.pack $ show x
+instance FromJSON RelationDegree where
+    parseJSON = withText "RelationDegree" (makeRelationDegree . T.unpack)
 
 -- |A datatype to represent AccessionID lists in a janno file
 type JannoAccessionIDList = JannoList AccessionID
@@ -456,14 +457,14 @@ makeAccessionID x
     | x Reg.=~ ("[EDS]RZ[0-9]{6,}"     :: String) = pure $ INSDCAnalysis x
     | otherwise                                   = pure $ OtherID x
 
-instance Csv.FromField AccessionID where
-    parseField x = Csv.parseField x >>= makeAccessionID
 instance Csv.ToField AccessionID where
     toField x = Csv.toField $ show x
-instance FromJSON AccessionID where
-    parseJSON = withText "AccessionID" (makeAccessionID . T.unpack)
+instance Csv.FromField AccessionID where
+    parseField x = Csv.parseField x >>= makeAccessionID
 instance ToJSON AccessionID where
     toEncoding x = text $ T.pack $ show x
+instance FromJSON AccessionID where
+    parseJSON = withText "AccessionID" (makeAccessionID . T.unpack)
 
 -- | A general datatype for janno list columns
 newtype JannoList a = JannoList {getJannoList :: [a]}
@@ -472,17 +473,17 @@ newtype JannoList a = JannoList {getJannoList :: [a]}
 type JannoStringList = JannoList String
 type JannoIntList = JannoList Int
 
+instance (Csv.ToField a) => Csv.ToField (JannoList a) where
+    toField = Csv.toField . intercalate ";" . map (read . show . Csv.toField) . getJannoList
 instance (Csv.FromField a) => Csv.FromField (JannoList a) where
     parseField x = do
         fieldStr <- Csv.parseField x
         let subStrings = Bchs.splitWith (==';') fieldStr
         fmap JannoList . mapM Csv.parseField $ subStrings
-instance (Csv.ToField a) => Csv.ToField (JannoList a) where
-    toField = Csv.toField . intercalate ";" . map (read . show . Csv.toField) . getJannoList
-instance (FromJSON a) => FromJSON (JannoList a) where
-    parseJSON v = JannoList <$> parseJSON v
 instance (ToJSON a) => ToJSON (JannoList a) where
     toEncoding (JannoList x) = toEncoding x
+instance (FromJSON a) => FromJSON (JannoList a) where
+    parseJSON v = JannoList <$> parseJSON v
 
 -- | A datatype to collect additional, unpecified .janno file columns (a hashmap in cassava/Data.Csv)
 newtype CsvNamedRecord = CsvNamedRecord Csv.NamedRecord deriving (Show, Eq, Generic)

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -65,6 +65,7 @@ import           SequenceFormats.Eigenstrat           (EigenstratIndEntry (..),
 import qualified Text.Regex.TDFA                      as Reg
 import qualified Data.Text as T
 import Data.Scientific (toBoundedInteger)
+import Data.Aeson.Encoding (text)
 
 -- | A datatype for genetic sex
 newtype JannoSex = JannoSex { sfSex :: Sex }
@@ -140,7 +141,8 @@ instance Csv.ToField BCADAge where
     toField (BCADAge x) = Csv.toField x
 
 -- |A datatype to represent Date_Type in a janno file
-data JannoDateType = C14
+data JannoDateType =
+      C14
     | Contextual
     | Modern
     deriving (Eq, Ord, Generic)
@@ -172,7 +174,8 @@ instance Csv.ToField JannoDateType where
     toField Modern     = "modern"
 
 -- |A datatype to represent Capture_Type in a janno file
-data JannoCaptureType = Shotgun
+data JannoCaptureType =
+      Shotgun
     | A1240K
     | ArborComplete
     | ArborPrimePlus
@@ -181,34 +184,6 @@ data JannoCaptureType = Shotgun
     | OtherCapture
     | ReferenceGenome
     deriving (Eq, Ord, Generic)
-
-instance ToJSON JannoCaptureType where
-    toEncoding = genericToEncoding defaultOptions
-
-instance FromJSON JannoCaptureType
-
-instance Csv.FromField JannoCaptureType where
-    parseField x
-        | x == "Shotgun"            = pure Shotgun
-        | x == "1240K"              = pure A1240K
-        | x == "ArborComplete"      = pure ArborComplete
-        | x == "ArborPrimePlus"     = pure ArborPrimePlus
-        | x == "ArborAncestralPlus" = pure ArborAncestralPlus
-        | x == "TwistAncientDNA"    = pure TwistAncientDNA
-        | x == "OtherCapture"       = pure OtherCapture
-        | x == "ReferenceGenome"    = pure ReferenceGenome
-        | otherwise                 = fail $ "Capture_Type " ++ show x ++
-                                          " not in [Shotgun, 1240K, ArborComplete, ArborPrimePlus, ArborAncestralPlus, TwistAncientDNA, OtherCapture, ReferenceGenome]"
-
-instance Csv.ToField JannoCaptureType where
-    toField Shotgun            = "Shotgun"
-    toField A1240K             = "1240K"
-    toField ArborComplete      = "ArborComplete"
-    toField ArborPrimePlus     = "ArborPrimePlus"
-    toField ArborAncestralPlus = "ArborAncestralPlus"
-    toField TwistAncientDNA    = "TwistAncientDNA"
-    toField OtherCapture       = "OtherCapture"
-    toField ReferenceGenome    = "ReferenceGenome"
 
 instance Show JannoCaptureType where
     show Shotgun            = "Shotgun"
@@ -220,29 +195,74 @@ instance Show JannoCaptureType where
     show OtherCapture       = "OtherCapture"
     show ReferenceGenome    = "ReferenceGenome"
 
+makeJannoCaptureType :: MonadFail m => String -> m JannoCaptureType
+makeJannoCaptureType x
+    | x == "Shotgun"            = pure Shotgun
+    | x == "1240K"              = pure A1240K
+    | x == "ArborComplete"      = pure ArborComplete
+    | x == "ArborPrimePlus"     = pure ArborPrimePlus
+    | x == "ArborAncestralPlus" = pure ArborAncestralPlus
+    | x == "TwistAncientDNA"    = pure TwistAncientDNA
+    | x == "OtherCapture"       = pure OtherCapture
+    | x == "ReferenceGenome"    = pure ReferenceGenome
+    | otherwise                 = fail $ "Capture_Type " ++ show x ++
+                                      " not in [Shotgun, 1240K, ArborComplete, ArborPrimePlus, ArborAncestralPlus, TwistAncientDNA, OtherCapture, ReferenceGenome]"
+
+instance FromJSON JannoCaptureType where
+    parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
+
+instance Csv.FromField JannoCaptureType where
+    parseField x = Csv.parseField x >>= makeJannoCaptureType
+
+instance ToJSON JannoCaptureType where
+    toEncoding Shotgun            = text "Shotgun"
+    toEncoding A1240K             = text "1240K"
+    toEncoding ArborComplete      = text "ArborComplete"
+    toEncoding ArborPrimePlus     = text "ArborPrimePlus"
+    toEncoding ArborAncestralPlus = text "ArborAncestralPlus"
+    toEncoding TwistAncientDNA    = text "TwistAncientDNA"
+    toEncoding OtherCapture       = text "OtherCapture"
+    toEncoding ReferenceGenome    = text "ReferenceGenome"
+
+instance Csv.ToField JannoCaptureType where
+    toField Shotgun            = "Shotgun"
+    toField A1240K             = "1240K"
+    toField ArborComplete      = "ArborComplete"
+    toField ArborPrimePlus     = "ArborPrimePlus"
+    toField ArborAncestralPlus = "ArborAncestralPlus"
+    toField TwistAncientDNA    = "TwistAncientDNA"
+    toField OtherCapture       = "OtherCapture"
+    toField ReferenceGenome    = "ReferenceGenome"
+
 -- |A datatype to represent Genotype_Ploidy in a janno file
-data JannoGenotypePloidy = Diploid
+data JannoGenotypePloidy =
+      Diploid
     | Haploid
     deriving (Eq, Ord, Generic)
-
-instance ToJSON JannoGenotypePloidy where
-    toEncoding = genericToEncoding defaultOptions
-
-instance FromJSON JannoGenotypePloidy
-
-instance Csv.FromField JannoGenotypePloidy where
-    parseField x
-        | x == "diploid" = pure Diploid
-        | x == "haploid" = pure Haploid
-        | otherwise      = fail $ "Genotype_Ploidy " ++ show x ++ " not in [diploid, haploid]"
-
-instance Csv.ToField JannoGenotypePloidy where
-    toField Diploid = "diploid"
-    toField Haploid = "haploid"
 
 instance Show JannoGenotypePloidy where
     show Diploid = "diploid"
     show Haploid = "haploid"
+
+makeJannoGenotypePloidy :: MonadFail m => String -> m JannoGenotypePloidy
+makeJannoGenotypePloidy x
+    | x == "diploid" = pure Diploid
+    | x == "haploid" = pure Haploid
+    | otherwise      = fail $ "Genotype_Ploidy " ++ show x ++ " not in [diploid, haploid]"
+
+instance FromJSON JannoGenotypePloidy where
+    parseJSON = withText "JannoGenotypePloidy" (makeJannoGenotypePloidy . T.unpack)
+
+instance Csv.FromField JannoGenotypePloidy where
+    parseField x = Csv.parseField x >>= makeJannoGenotypePloidy
+
+instance ToJSON JannoGenotypePloidy where
+    toEncoding Diploid = text "diploid"
+    toEncoding Haploid = text "haploid"
+
+instance Csv.ToField JannoGenotypePloidy where
+    toField Diploid = "diploid"
+    toField Haploid = "haploid"
 
 -- |A datatype to represent UDG in a janno file
 data JannoUDG = Minus

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -105,9 +105,7 @@ instance ToJSON JannoSex where
     toJSON (JannoSex Unknown) = String "U"
 
 instance Csv.ToField JannoSex where
-    toField (JannoSex Female)  = "F"
-    toField (JannoSex Male)    = "M"
-    toField (JannoSex Unknown) = "U"
+    toField x = Csv.toField $ show x
 
 -- | A datatype for BC-AD ages
 newtype BCADAge =
@@ -166,12 +164,10 @@ instance Csv.FromField JannoDateType where
     parseField x = Csv.parseField x >>= makeJannoDateType
 
 instance ToJSON JannoDateType where
-    toEncoding = genericToEncoding defaultOptions
+    toEncoding x = text $ T.pack $ show x
 
 instance Csv.ToField JannoDateType where
-    toField C14        = "C14"
-    toField Contextual = "contextual"
-    toField Modern     = "modern"
+    toField x = Csv.toField $ show x
 
 -- |A datatype to represent Capture_Type in a janno file
 data JannoCaptureType =
@@ -215,24 +211,10 @@ instance Csv.FromField JannoCaptureType where
     parseField x = Csv.parseField x >>= makeJannoCaptureType
 
 instance ToJSON JannoCaptureType where
-    toEncoding Shotgun            = text "Shotgun"
-    toEncoding A1240K             = text "1240K"
-    toEncoding ArborComplete      = text "ArborComplete"
-    toEncoding ArborPrimePlus     = text "ArborPrimePlus"
-    toEncoding ArborAncestralPlus = text "ArborAncestralPlus"
-    toEncoding TwistAncientDNA    = text "TwistAncientDNA"
-    toEncoding OtherCapture       = text "OtherCapture"
-    toEncoding ReferenceGenome    = text "ReferenceGenome"
+    toEncoding x = text $ T.pack $ show x
 
 instance Csv.ToField JannoCaptureType where
-    toField Shotgun            = "Shotgun"
-    toField A1240K             = "1240K"
-    toField ArborComplete      = "ArborComplete"
-    toField ArborPrimePlus     = "ArborPrimePlus"
-    toField ArborAncestralPlus = "ArborAncestralPlus"
-    toField TwistAncientDNA    = "TwistAncientDNA"
-    toField OtherCapture       = "OtherCapture"
-    toField ReferenceGenome    = "ReferenceGenome"
+    toField x = Csv.toField $ show x
 
 -- |A datatype to represent Genotype_Ploidy in a janno file
 data JannoGenotypePloidy =
@@ -434,7 +416,7 @@ instance (Csv.FromField a) => Csv.FromField (JannoList a) where
         fmap JannoList . mapM Csv.parseField $ subStrings
 
 instance (ToJSON a) => ToJSON (JannoList a) where
-    toJSON (JannoList x) = toJSON x
+    toEncoding (JannoList x) = toEncoding x
 
 instance (FromJSON a) => FromJSON (JannoList a) where
     parseJSON v = JannoList <$> parseJSON v

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -229,36 +229,35 @@ instance ToJSON JannoGenotypePloidy where
     toEncoding x = text $ T.pack $ show x
 
 -- |A datatype to represent UDG in a janno file
-data JannoUDG = Minus
+data JannoUDG =
+      Minus
     | Half
     | Plus
     | Mixed
     deriving (Eq, Ord, Generic)
-
-instance ToJSON JannoUDG where
-    toEncoding = genericToEncoding defaultOptions
-
-instance FromJSON JannoUDG
-
-instance Csv.FromField JannoUDG where
-    parseField x
-        | x == "minus" = pure Minus
-        | x == "half"  = pure Half
-        | x == "plus"  = pure Plus
-        | x == "mixed" = pure Mixed
-        | otherwise    = fail $ "UDG " ++ show x ++ " not in [minus, half, plus, mixed]"
-
-instance Csv.ToField JannoUDG where
-    toField Minus = "minus"
-    toField Half  = "half"
-    toField Plus  = "plus"
-    toField Mixed = "mixed"
 
 instance Show JannoUDG where
     show Minus = "minus"
     show Half  = "half"
     show Plus  = "plus"
     show Mixed = "mixed"
+
+makeJannoUDG :: MonadFail m => String -> m JannoUDG
+makeJannoUDG x
+    | x == "minus" = pure Minus
+    | x == "half"  = pure Half
+    | x == "plus"  = pure Plus
+    | x == "mixed" = pure Mixed
+    | otherwise    = fail $ "UDG " ++ show x ++ " not in [minus, half, plus, mixed]"
+
+instance Csv.FromField JannoUDG where
+    parseField x = Csv.parseField x >>= makeJannoUDG
+instance Csv.ToField JannoUDG where
+    toField x = Csv.toField $ show x
+instance FromJSON JannoUDG where
+    parseJSON = withText "JannoUDG" (makeJannoUDG . T.unpack)
+instance ToJSON JannoUDG where
+    toEncoding x = text $ T.pack $ show x
 
 -- |A datatype to represent Library_Built in a janno file
 data JannoLibraryBuilt = DS

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -94,14 +94,14 @@ makeJannoSex x
     | x == "U"  = pure (JannoSex Unknown)
     | otherwise = fail $ "Sex " ++ show x ++ " not in [F, M, U]"
 
-instance FromJSON JannoSex where
-    parseJSON = withText "JannoSex" (makeJannoSex . T.unpack)
 instance Csv.FromField JannoSex where
     parseField x = Csv.parseField x >>= makeJannoSex
-instance ToJSON JannoSex where
-    toJSON x  = String $ T.pack $ show x
 instance Csv.ToField JannoSex where
     toField x = Csv.toField $ show x
+instance FromJSON JannoSex where
+    parseJSON = withText "JannoSex" (makeJannoSex . T.unpack)
+instance ToJSON JannoSex where
+    toJSON x  = String $ T.pack $ show x
 
 -- | A datatype for BC-AD ages
 newtype BCADAge =


### PR DESCRIPTION
In this PR I collect the changes for #167.

Here's some test code to check if en- and decoding to JSON works as expected:

> (decode $ encode $ JannoRow {jPoseidonID = "1", jAlternativeIDs = Nothing, jRelationTo = Nothing, jRelationDegree = Nothing, jRelationType = Nothing, jRelationNote = Nothing, jCollectionID = Nothing, jSourceTissue = Nothing, jCountry = Nothing, jLocation = Nothing, jSite = Nothing, jLatitude = Nothing, jLongitude = Nothing, jDateC14Labnr = Nothing, jDateC14UncalBP = Nothing, jDateC14UncalBPErr = Nothing, jDateBCADMedian = Just $ BCADAge 191, jDateBCADStart = Nothing, jDateBCADStop = Nothing, jDateType = Just C14, jDateNote = Nothing, jNrLibraries = Nothing, jCaptureType = Just $ JannoList [Shotgun, TwistAncientDNA, A1240K], jGenotypePloidy = Just Diploid, jGroupName = JannoList {getJannoList = ["huhu"]}, jGeneticSex = JannoSex Female, jNrSNPs = Nothing, jCoverageOnTargets = Nothing, jMTHaplogroup = Nothing, jYHaplogroup = Nothing, jEndogenous = Nothing, jUDG = Nothing, jLibraryBuilt = Nothing, jDamage = Nothing, jContamination = Nothing, jContaminationErr = Nothing, jContaminationMeas = Nothing, jContaminationNote = Nothing, jGeneticSourceAccessionIDs = Nothing, jDataPreparationPipelineURL = Nothing, jPrimaryContact = Nothing, jPublication = Nothing, jComments = Nothing, jKeywords = Nothing, jAdditionalColumns = CsvNamedRecord (HM.fromList [("de", "ab"), ("gugu", "45")])}):: Maybe JannoRow
