### PR TITLE
fix server-client interaction broken since 1.1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- V 1.1.8.5: Rolled back some of the ToJSON instances changed in 1.1.8.4 because they broke backwards compatibility of the server-client communication. Added some additional tests to prevent such oversights in the future. Slightly reorganized the golden tests
 - V 1.1.8.4: Unified the implementation of ToJSON/FromJSON and ToField/FromField instances for .janno datatypes to perform input validation through smart constructors
 - V 1.1.8.3: The fix in introduced in 1.1.8.1 introduced a bug: It broke valid unicode characters in .janno files and prevented reading them. The solution implemented here solves this issue
 - V 1.1.8.2: Improved the behaviour of `list` when provided with undefined .janno columns in the `-j` argument

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -1,5 +1,5 @@
 name:                poseidon-hs
-version:             1.1.8.4
+version:             1.1.8.5
 synopsis:            A package with tools for working with Poseidon Genotype Data
 description:         The tools in this package read and analyse Poseidon-formatted genotype databases, a modular system for storing genotype data from thousands of individuals.
 license:             MIT

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -60,8 +60,8 @@ Test-Suite poseidon-tools-tests
     other-modules:      Poseidon.PackageSpec, Poseidon.JannoSpec,
                         Poseidon.BibFileSpec, Poseidon.MathHelpersSpec,
                         Poseidon.SummariseSpec, Poseidon.SurveySpec, Poseidon.GenotypeDataSpec,
-                        Poseidon.GoldenTestsValidateChecksumsSpec, Poseidon.GoldenTestsRunCommands,
-                        Poseidon.EntitiesListSpec
+                        Poseidon.EntitiesListSpec, PoseidonGoldenTests.GoldenTestsValidateChecksumsSpec,
+                        PoseidonGoldenTests.GoldenTestsRunCommands
   default-language:     Haskell2010
 
 executable poseidon-devtools
@@ -69,5 +69,5 @@ executable poseidon-devtools
     hs-source-dirs:     test, src-executables
     build-depends:      base, poseidon-hs, optparse-applicative, directory,
                         filepath, text, unordered-containers, bytestring
-    other-modules:      Paths_poseidon_hs, Poseidon.GoldenTestsRunCommands
+    other-modules:      Paths_poseidon_hs, PoseidonGoldenTests.GoldenTestsRunCommands
     default-language:   Haskell2010

--- a/src-executables/Main-devtools.hs
+++ b/src-executables/Main-devtools.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import           Paths_poseidon_hs               (version)
-import           Poseidon.GoldenTestsRunCommands (createStaticCheckSumFile)
+import           Paths_poseidon_hs                          (version)
+import           PoseidonGoldenTests.GoldenTestsRunCommands (createStaticCheckSumFile)
 
-import           Data.Version                    (showVersion)
-import qualified Options.Applicative             as OP
-import           System.IO                       (hPutStrLn, stderr)
+import           Data.Version                               (showVersion)
+import qualified Options.Applicative                        as OP
+import           System.IO                                  (hPutStrLn, stderr)
 
 data UpdateGoldenTestsOptions = UpdateGoldenTestsOptions
     { _optPoseidonHSDir :: FilePath

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -42,9 +42,8 @@ import           Data.Aeson                           (FromJSON, Options (..),
                                                        defaultOptions,
                                                        genericToEncoding,
                                                        parseJSON, toEncoding,
-                                                       toJSON, withScientific,
-                                                       withText)
-import           Data.Aeson.Encoding                  (text)
+                                                       toJSON, withText)
+import           Data.Aeson.Types                     (emptyObject)
 import           Data.Bifunctor                       (second)
 import qualified Data.ByteString.Char8                as Bchs
 import qualified Data.ByteString.Lazy.Char8           as Bch
@@ -56,8 +55,6 @@ import           Data.List                            (elemIndex, foldl',
                                                        intercalate, nub, sort,
                                                        (\\))
 import           Data.Maybe                           (fromJust, isNothing)
-import           Data.Scientific                      (toBoundedInteger,
-                                                       toRealFloat)
 import           Data.Text                            (pack, replace, unpack)
 import qualified Data.Text                            as T
 import qualified Data.Text.Encoding                   as T
@@ -125,11 +122,11 @@ instance Csv.FromField BCADAge where
     parseField x = Csv.parseField x >>= makeBCADAge
 instance ToJSON BCADAge where
     toEncoding = genericToEncoding defaultOptions
-instance FromJSON BCADAge where
-    parseJSON = withScientific "BCADAge" $ \n ->
-        case toBoundedInteger n of
-            Nothing -> fail $ "Number" ++ show n ++ "doesn't fit into a bounded integer."
-            Just x -> makeBCADAge x
+instance FromJSON BCADAge-- where
+    --parseJSON = withScientific "BCADAge" $ \n ->
+    --    case toBoundedInteger n of
+    --        Nothing -> fail $ "Number" ++ show n ++ "doesn't fit into a bounded integer."
+    --        Just x -> makeBCADAge x
 
 -- |A datatype to represent Date_Type in a janno file
 data JannoDateType =
@@ -155,9 +152,10 @@ instance Csv.ToField JannoDateType where
 instance Csv.FromField JannoDateType where
     parseField x = Csv.parseField x >>= makeJannoDateType
 instance ToJSON JannoDateType where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON JannoDateType where
-    parseJSON = withText "JannoDateType" (makeJannoDateType . T.unpack)
+    toEncoding = genericToEncoding defaultOptions
+    --toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoDateType-- where
+    --parseJSON = withText "JannoDateType" (makeJannoDateType . T.unpack)
 
 -- |A datatype to represent Capture_Type in a janno file
 data JannoCaptureType =
@@ -199,9 +197,10 @@ instance Csv.ToField JannoCaptureType where
 instance Csv.FromField JannoCaptureType where
     parseField x = Csv.parseField x >>= makeJannoCaptureType
 instance ToJSON JannoCaptureType where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON JannoCaptureType where
-    parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
+    toEncoding = genericToEncoding defaultOptions
+    --toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoCaptureType-- where
+    --parseJSON = withText "JannoCaptureType" (makeJannoCaptureType . T.unpack)
 
 -- |A datatype to represent Genotype_Ploidy in a janno file
 data JannoGenotypePloidy =
@@ -224,9 +223,10 @@ instance Csv.ToField JannoGenotypePloidy where
 instance Csv.FromField JannoGenotypePloidy where
     parseField x = Csv.parseField x >>= makeJannoGenotypePloidy
 instance ToJSON JannoGenotypePloidy where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON JannoGenotypePloidy where
-    parseJSON = withText "JannoGenotypePloidy" (makeJannoGenotypePloidy . T.unpack)
+    toEncoding = genericToEncoding defaultOptions
+    --toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoGenotypePloidy-- where
+    --parseJSON = withText "JannoGenotypePloidy" (makeJannoGenotypePloidy . T.unpack)
 
 -- |A datatype to represent UDG in a janno file
 data JannoUDG =
@@ -255,9 +255,10 @@ instance Csv.ToField JannoUDG where
 instance Csv.FromField JannoUDG where
     parseField x = Csv.parseField x >>= makeJannoUDG
 instance ToJSON JannoUDG where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON JannoUDG where
-    parseJSON = withText "JannoUDG" (makeJannoUDG . T.unpack)
+    toEncoding = genericToEncoding defaultOptions
+    --toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoUDG-- where
+    --parseJSON = withText "JannoUDG" (makeJannoUDG . T.unpack)
 
 -- |A datatype to represent Library_Built in a janno file
 data JannoLibraryBuilt =
@@ -283,9 +284,10 @@ instance Csv.ToField JannoLibraryBuilt where
 instance Csv.FromField JannoLibraryBuilt where
     parseField x = Csv.parseField x >>= makeJannoLibraryBuilt
 instance ToJSON JannoLibraryBuilt where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON JannoLibraryBuilt where
-    parseJSON = withText "JannoLibraryBuilt" (makeJannoLibraryBuilt . T.unpack)
+    toEncoding = genericToEncoding defaultOptions
+    --toEncoding x = text $ T.pack $ show x
+instance FromJSON JannoLibraryBuilt --where
+    --parseJSON = withText "JannoLibraryBuilt" (makeJannoLibraryBuilt . T.unpack)
 
 -- | A datatype for Latitudes
 newtype Latitude =
@@ -306,8 +308,8 @@ instance Csv.FromField Latitude where
     parseField x = Csv.parseField x >>= makeLatitude
 instance ToJSON Latitude where
     toEncoding = genericToEncoding defaultOptions
-instance FromJSON Latitude where
-    parseJSON = withScientific "Latitude" $ \n -> (makeLatitude . toRealFloat) n
+instance FromJSON Latitude-- where
+    --parseJSON = withScientific "Latitude" $ \n -> (makeLatitude . toRealFloat) n
 
 -- | A datatype for Longitudes
 newtype Longitude =
@@ -328,8 +330,8 @@ instance Csv.FromField Longitude where
     parseField x = Csv.parseField x >>= makeLongitude
 instance ToJSON Longitude where
     toEncoding = genericToEncoding defaultOptions
-instance FromJSON Longitude where
-    parseJSON = withScientific "Longitude" $ \n -> (makeLongitude . toRealFloat) n
+instance FromJSON Longitude-- where
+    --parseJSON = withScientific "Longitude" $ \n -> (makeLongitude . toRealFloat) n
 
 -- | A datatype for Percent values
 newtype Percent =
@@ -350,8 +352,8 @@ instance Csv.FromField Percent where
     parseField x = Csv.parseField x >>= makePercent
 instance ToJSON Percent where
     toEncoding = genericToEncoding defaultOptions
-instance FromJSON Percent where
-    parseJSON = withScientific "Percent" $ \n -> (makePercent . toRealFloat) n
+instance FromJSON Percent-- where
+    --parseJSON = withScientific "Percent" $ \n -> (makePercent . toRealFloat) n
 
 -- | A datatype to represent URIs in a janno file
 newtype JURI =
@@ -371,9 +373,10 @@ instance Csv.ToField JURI where
 instance Csv.FromField JURI where
     parseField x = Csv.parseField x >>= makeJURI
 instance ToJSON JURI where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON JURI where
-    parseJSON = withText "JURI" (makeJURI . T.unpack)
+    toEncoding = genericToEncoding defaultOptions
+    --toEncoding x = text $ T.pack $ show x
+instance FromJSON JURI-- where
+    --parseJSON = withText "JURI" (makeJURI . T.unpack)
 
 -- |A datatype to represent Relationship degree lists in a janno file
 type JannoRelationDegreeList = JannoList RelationDegree
@@ -416,9 +419,10 @@ instance Csv.ToField RelationDegree where
 instance Csv.FromField RelationDegree where
     parseField x = Csv.parseField x >>= makeRelationDegree
 instance ToJSON RelationDegree where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON RelationDegree where
-    parseJSON = withText "RelationDegree" (makeRelationDegree . T.unpack)
+    toEncoding = genericToEncoding defaultOptions
+    --toEncoding x = text $ T.pack $ show x
+instance FromJSON RelationDegree-- where
+    --parseJSON = withText "RelationDegree" (makeRelationDegree . T.unpack)
 
 -- |A datatype to represent AccessionID lists in a janno file
 type JannoAccessionIDList = JannoList AccessionID
@@ -462,9 +466,10 @@ instance Csv.ToField AccessionID where
 instance Csv.FromField AccessionID where
     parseField x = Csv.parseField x >>= makeAccessionID
 instance ToJSON AccessionID where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON AccessionID where
-    parseJSON = withText "AccessionID" (makeAccessionID . T.unpack)
+    toEncoding = genericToEncoding defaultOptions
+    --toEncoding x = text $ T.pack $ show x
+instance FromJSON AccessionID-- where
+    --parseJSON = withText "AccessionID" (makeAccessionID . T.unpack)
 
 -- | A general datatype for janno list columns
 newtype JannoList a = JannoList {getJannoList :: [a]}
@@ -498,10 +503,12 @@ instance ToJSON CsvNamedRecord where
             listOfTextTuples = map (\(a,b) -> (T.decodeUtf8 a, T.decodeUtf8 b)) listOfBSTuples
         in toJSON listOfTextTuples
 instance FromJSON CsvNamedRecord where
-    parseJSON x = do
-        listOfTextTuples <- parseJSON x -- :: [(T.Text, T.Text)]
-        let listOfBSTuples = map (\(a,b) -> (T.encodeUtf8 a, T.encodeUtf8 b)) listOfTextTuples
-        pure $ CsvNamedRecord $ HM.fromList listOfBSTuples
+    parseJSON x
+        | x == emptyObject = pure $ CsvNamedRecord $ HM.fromList []
+        | otherwise = do
+            listOfTextTuples <- parseJSON x -- :: [(T.Text, T.Text)]
+            let listOfBSTuples = map (\(a,b) -> (T.encodeUtf8 a, T.encodeUtf8 b)) listOfTextTuples
+            pure $ CsvNamedRecord $ HM.fromList listOfBSTuples
 
 -- | A data type to represent a sample/janno file row
 -- See https://github.com/poseidon-framework/poseidon2-schema/blob/master/janno_columns.tsv

--- a/test/Poseidon/GoldenTestsRunCommands.hs
+++ b/test/Poseidon/GoldenTestsRunCommands.hs
@@ -23,7 +23,7 @@ import           Poseidon.GenotypeData    (GenoDataSource (..),
                                            GenotypeFormatSpec (..),
                                            SNPSetSpec (..))
 import           Poseidon.Janno           (CsvNamedRecord (..), JannoRow (..),
-                                           readJannoFile, writeJannoFile)
+                                           readJannoFile, writeJannoFile, jannoHeaderString)
 import           Poseidon.SecondaryTypes  (ContributorSpec (..),
                                            VersionComponent (..))
 import           Poseidon.Utils           (getChecksum, testLog)
@@ -85,24 +85,28 @@ runCLICommands interactive testDir checkFilePath testPacsDir testEntityFiles = d
     stderr_old <- hDuplicate stderr
     unless interactive $ hDuplicateTo devNull stderr
     -- run CLI pipeline
-    hPutStrLn stderr "--- init ---"
+    hPutStrLn stderr "--* local tests"
+    hPutStrLn stderr "--- init"
     testPipelineInit testDir checkFilePath testPacsDir
-    hPutStrLn stderr "--- validate ---"
+    hPutStrLn stderr "--- validate"
     testPipelineValidate testDir checkFilePath
-    hPutStrLn stderr "--- list ---"
+    hPutStrLn stderr "--- list"
     testPipelineList testDir checkFilePath
-    hPutStrLn stderr "--- summarise ---"
+    hPutStrLn stderr "--- summarise"
     testPipelineSummarise testDir checkFilePath
-    hPutStrLn stderr "--- survey ---"
+    hPutStrLn stderr "--- survey"
     testPipelineSurvey testDir checkFilePath
-    hPutStrLn stderr "--- genoconvert ---"
+    hPutStrLn stderr "--- genoconvert"
     testPipelineGenoconvert testDir checkFilePath
-    hPutStrLn stderr "--- update ---"
+    hPutStrLn stderr "--- update"
     testPipelineUpdate testDir checkFilePath
-    hPutStrLn stderr "--- forge ---"
+    hPutStrLn stderr "--- forge"
     testPipelineForge testDir checkFilePath testEntityFiles
-    hPutStrLn stderr "--- fetch ---"
+    hPutStrLn stderr "--* test server interaction"
+    hPutStrLn stderr "--- fetch"
     testPipelineFetch testDir checkFilePath
+    hPutStrLn stderr "--- list --remote"
+    testPipelineListRemote
     -- close error sink
     hClose devNull
     unless interactive $ hDuplicateTo stderr_old stderr
@@ -646,6 +650,28 @@ testPipelineFetch testDir checkFilePath = do
         , "2019_Nikitin_LBK" </> "Nikitin_LBK.fam"
         ]
 
+-- this tests only if the commands run without an error
+-- the results are not stored like for the other golden tests,
+-- because the data available on the server changes
+testPipelineListRemote :: IO ()
+testPipelineListRemote = do
+    let listOpts1 = ListOptions {
+          _listRepoLocation = RepoRemote "http://c107-224.cloud.gwdg.de:3000"
+        , _listListEntity   = ListPackages
+        , _listRawOutput    = False
+        , _listIgnoreGeno   = False
+        }
+    writeStdOutToFile "/dev/null" (testLog $ runList listOpts1)
+    let listOpts2 = listOpts1 {
+          _listListEntity    = ListGroups
+        }
+    writeStdOutToFile "/dev/null" (testLog $ runList listOpts2)
+    let listOpts3 = listOpts1 {
+          _listListEntity    = ListIndividuals jannoHeaderString
+        , _listRawOutput     = True
+        }
+    writeStdOutToFile "/dev/null" (testLog $ runList listOpts3)
+
 runAndChecksumFiles :: FilePath -> FilePath -> IO () -> String -> [FilePath] -> IO ()
 runAndChecksumFiles checkSumFilePath testDir action actionName outFiles = do
     -- run action
@@ -662,15 +688,19 @@ runAndChecksumStdOut :: FilePath -> FilePath -> IO () -> String -> Integer -> IO
 runAndChecksumStdOut checkSumFilePath testDir action actionName outFileNumber = do
     -- store stdout in a specific output file
     let outFile = actionName ++ show outFileNumber
-    withFile (testDir </> outFile) WriteMode $ \handle -> do
-        -- backup stdout handle
-        stdout_old <- hDuplicate stdout
-        -- redirect stdout to file
-        hDuplicateTo handle stdout
-        -- run action
-        action
-        -- load backup again
-        hDuplicateTo stdout_old stdout
+    writeStdOutToFile (testDir </> outFile) action
     -- append checksum to checksumfile
     checksum <- getChecksum $ testDir </> outFile
     appendFile checkSumFilePath $ "\n" ++ checksum ++ " " ++ actionName ++ " " ++ outFile
+
+writeStdOutToFile :: FilePath -> IO () -> IO ()
+writeStdOutToFile path action =
+    withFile path WriteMode $ \handle -> do
+      -- backup stdout handle
+      stdout_old <- hDuplicate stdout
+      -- redirect stdout to file
+      hDuplicateTo handle stdout
+      -- run action
+      action
+      -- load backup again
+      hDuplicateTo stdout_old stdout

--- a/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
+++ b/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Poseidon.GoldenTestsRunCommands (
+module PoseidonGoldenTests.GoldenTestsRunCommands (
     createStaticCheckSumFile, createDynamicCheckSumFile, staticCheckSumFile, dynamicCheckSumFile
     ) where
 
@@ -23,7 +23,8 @@ import           Poseidon.GenotypeData    (GenoDataSource (..),
                                            GenotypeFormatSpec (..),
                                            SNPSetSpec (..))
 import           Poseidon.Janno           (CsvNamedRecord (..), JannoRow (..),
-                                           readJannoFile, writeJannoFile, jannoHeaderString)
+                                           jannoHeaderString, readJannoFile,
+                                           writeJannoFile)
 import           Poseidon.SecondaryTypes  (ContributorSpec (..),
                                            VersionComponent (..))
 import           Poseidon.Utils           (getChecksum, testLog)

--- a/test/PoseidonGoldenTests/GoldenTestsValidateChecksumsSpec.hs
+++ b/test/PoseidonGoldenTests/GoldenTestsValidateChecksumsSpec.hs
@@ -1,8 +1,8 @@
-module Poseidon.GoldenTestsValidateChecksumsSpec (spec) where
+module PoseidonGoldenTests.GoldenTestsValidateChecksumsSpec (spec) where
 
-import           Poseidon.GoldenTestsRunCommands (createDynamicCheckSumFile,
-                                                  dynamicCheckSumFile,
-                                                  staticCheckSumFile)
+import           PoseidonGoldenTests.GoldenTestsRunCommands (createDynamicCheckSumFile,
+                                                             dynamicCheckSumFile,
+                                                             staticCheckSumFile)
 
 import           Test.Hspec
 


### PR DESCRIPTION
v1.1.8.4 (#221) broke the communication between old (before 1.1.8.4) versions of `poseidon-http-server` and new versions of `trident`. This was foreseeable, yet unforeseen

This PR is meant to fix this incompatibility by reverting some of the JSON encoding/decoding related changes. This is not entirely trivial, because we do need a working JSON scheme for `CsvNamedRecord` (which did not exist in the past). To make sure that everything works, we need to consider the following cases:

- [x] 1. Old server + New client
- [x] 2. New server + Old client
- [x] 3. New server + New client

I ran some quick tests on the command line with a local server, and old and new client versions.
```bash
# v1.1.8.5 client + old (?) server
trident list --remote --packages | --groups | --individuals  -j Nr_SNPs

#  v1.1.8.5 client +  v1.1.8.5 server
poseidon-http-server -d 2010_RasmussenNature -c -z testDir
trident list --remote --remoteURL "http://127.0.0.1:3000" --packages | --groups | --individuals -j Nr_SNPs

#  v1.1.7.0 client + v1.1.8.5 server
wget https://github.com/poseidon-framework/poseidon-hs/releases/latest/download/trident-Linux
chmod +x trident-Linux
./trident-Linux list --remote --remoteURL "http://127.0.0.1:3000" --packages | --groups | --individuals -j Nr_SNPs
```
Works for all combinations.