### PR TITLE
Minor changes

### DIFF
--- a/src/Poseidon/CLI/Update.hs
+++ b/src/Poseidon/CLI/Update.hs
@@ -81,7 +81,7 @@ writeOrUpdateChangelogFile logText pac = do
     case posPacChangelogFile pac of
         Nothing -> do
             writeFile (posPacBaseDir pac </> "CHANGELOG.md") $
-                "V " ++ showVersion (fromJust $ posPacPackageVersion pac) ++ ": " ++ logText ++ "\n"
+                "- V " ++ showVersion (fromJust $ posPacPackageVersion pac) ++ ": " ++ logText ++ "\n"
             return pac {
                 posPacChangelogFile = Just "CHANGELOG.md"
             }
@@ -89,7 +89,7 @@ writeOrUpdateChangelogFile logText pac = do
             changelogFile <- readFile (posPacBaseDir pac </> x)
             removeFile (posPacBaseDir pac </> x)
             writeFile (posPacBaseDir pac </> x) $
-                "V " ++ showVersion (fromJust $ posPacPackageVersion pac) ++ ": " ++ logText ++ "\n" ++ changelogFile
+                "- V " ++ showVersion (fromJust $ posPacPackageVersion pac) ++ ": " ++ logText ++ "\n" ++ changelogFile
             return pac
 
 updateMeta :: VersionComponent -> Day -> [ContributorSpec] -> PoseidonPackage -> PoseidonPackage

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -877,8 +877,8 @@ readJannoFile jannoPath = do
     let jannoColNames = map Bch.toStrict (Bch.split '\t' headerOnly)
         missing_columns = map Bchs.unpack $ jannoHeader \\ jannoColNames
         additional_columns = map Bchs.unpack $ jannoColNames \\ jannoHeader
-    unless (null missing_columns) $ do
-        logDebug ("Missing standard columns: " ++ intercalate ", " missing_columns)
+    --unless (null missing_columns) $ do
+    --    logDebug ("Missing standard columns: " ++ intercalate ", " missing_columns)
     unless (null additional_columns) $ do
         logDebug ("Additional columns: " ++
         -- for each additional column a standard column is suggested: "Countro (Country?)"

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -20,6 +20,8 @@ module Poseidon.Utils (
     determinePackageOutName
 ) where
 
+import           Paths_poseidon_hs                       (version)
+
 import           Colog                  (HasLog (..), LogAction (..), Message,
                                          Msg (..), Severity (..), cfilter,
                                          cmapM, logTextStderr, msgSeverity,
@@ -39,6 +41,7 @@ import           Data.Yaml              (ParseException)
 import           GHC.Stack              (callStack, withFrozenCallStack)
 import           System.Directory       (doesFileExist)
 import           System.FilePath.Posix  (takeBaseName)
+import           Data.Version                            (showVersion)
 
 type LogEnv = LogAction IO Message
 
@@ -151,7 +154,9 @@ renderPoseidonException (PoseidonPackageException s) =
     "Encountered a logical error with a poseidon package: " ++ s
 renderPoseidonException (PoseidonPackageVersionException p s) =
     "Poseidon version mismatch in " ++ show p ++
-    ". It has version \"" ++ s ++ "\", which is not supported by this trident version."
+    ". This package is build according to poseidon schema v" ++ s ++
+    ", which is not supported by trident v" ++ showVersion version ++
+    ". Modify the package, or download a newer (or older) version of trident."
 renderPoseidonException (PoseidonPackageMissingVersionException p) =
     "The POSEIDON.yml file " ++ show p ++ " has no poseidonVersion field. " ++
     "This is mandatory."

--- a/src/Poseidon/Utils.hs
+++ b/src/Poseidon/Utils.hs
@@ -20,7 +20,7 @@ module Poseidon.Utils (
     determinePackageOutName
 ) where
 
-import           Paths_poseidon_hs                       (version)
+import           Paths_poseidon_hs      (version)
 
 import           Colog                  (HasLog (..), LogAction (..), Message,
                                          Msg (..), Severity (..), cfilter,
@@ -37,11 +37,11 @@ import           Data.Digest.Pure.MD5   (md5)
 import           Data.Text              (Text, pack)
 import           Data.Time              (defaultTimeLocale, formatTime,
                                          getCurrentTime, utcToLocalZonedTime)
+import           Data.Version           (showVersion)
 import           Data.Yaml              (ParseException)
 import           GHC.Stack              (callStack, withFrozenCallStack)
 import           System.Directory       (doesFileExist)
 import           System.FilePath.Posix  (takeBaseName)
-import           Data.Version                            (showVersion)
 
 type LogEnv = LogAction IO Message
 

--- a/test/testDat/poseidonHSGoldenTestCheckSumFile.txt
+++ b/test/testDat/poseidonHSGoldenTestCheckSumFile.txt
@@ -28,11 +28,11 @@ a9fcb59cb933d8f183f3c3f6fbf2e213 genoconvert Schiffels/Schiffels.fam
 8538ffd971ebb12cf5ef6e338da27970 genoconvert Schiffels/geno.bim
 a9fcb59cb933d8f183f3c3f6fbf2e213 genoconvert Schiffels/geno.fam
 5166a51ecfe9e133b1a5d66ed560b80d update Schiffels/POSEIDON.yml
-aee009e147a8680bb9a8ec785ae5b664 update Schiffels/CHANGELOG.md
+4aeae97cfc44b55b2a8005425d786148 update Schiffels/CHANGELOG.md
 8cc39be40bd246efc9d861e69ee6682f update Schiffels/POSEIDON.yml
-26365b759ce69eea16c62152ffce2938 update Schiffels/CHANGELOG.md
+3bb396e099d5b8771a3409f5fe85d70b update Schiffels/CHANGELOG.md
 ef0fe28cf498a373b29c7619aac3720a update Schiffels/POSEIDON.yml
-2dabf673712faabac1403e1002bec9e0 update Schiffels/CHANGELOG.md
+fdda0f630a68f0da74e35a21d8f748a8 update Schiffels/CHANGELOG.md
 38b61b93e299e6ba14cd23cd6eaa873a forge ForgePac1/POSEIDON.yml
 1286a2580e4bfbed7d804d5f3fe125f7 forge ForgePac1/ForgePac1.geno
 c613af8349f6c05927ee0771021f9b7d forge ForgePac1/ForgePac1.janno

--- a/test/testDat/poseidonHSGoldenTestData/Schiffels/CHANGELOG.md
+++ b/test/testDat/poseidonHSGoldenTestData/Schiffels/CHANGELOG.md
@@ -1,3 +1,3 @@
-V 1.1.1: test3
-V 1.1.0: test2
-V 1.0.0: test1
+- V 1.1.1: test3
+- V 1.1.0: test2
+- V 1.0.0: test1


### PR DESCRIPTION
In this PR I wanted to collect a number of small adjustments:

- [x] made trident update write messages to the CHANGELOG file now with a `-` (to make it proper markdown, as discussed in https://github.com/poseidon-framework/published_data/issues/62)
- [x] turned off verbose debug-level warnings about missing standard columns
- [x] #227