### PR TITLE
`trident snapshot`

### DIFF
--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -15,12 +15,12 @@ extra-source-files:  README.md,
 library
     exposed-modules:    Poseidon.Package, Poseidon.GenotypeData, Poseidon.BibFile, Poseidon.Janno,
                         Poseidon.EntitiesList, Poseidon.MathHelpers, Poseidon.SecondaryTypes,
-                        Poseidon.PoseidonVersion,
-                        Poseidon.CLI.List, 
+                        Poseidon.PoseidonVersion, Poseidon.SequencingSource, Poseidon.Snapshot,
+                        Poseidon.CLI.List, Poseidon.CLI.Snapshot,
                         Poseidon.CLI.Summarise, Poseidon.CLI.Validate, Poseidon.Utils,
                         Poseidon.CLI.Survey, Poseidon.CLI.Forge, Poseidon.CLI.Init,
                         Poseidon.CLI.Update, Poseidon.CLI.Fetch, Poseidon.CLI.Genoconvert,
-                        Poseidon.CLI.OptparseApplicativeParsers, Poseidon.SequencingSource
+                        Poseidon.CLI.OptparseApplicativeParsers
     other-modules:      Paths_poseidon_hs
     hs-source-dirs:     src
     build-depends:      base >= 4.7 && < 5, sequence-formats>=1.6.1, text, time, pipes-safe,

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -25,7 +25,7 @@ library
     hs-source-dirs:     src
     build-depends:      base >= 4.7 && < 5, sequence-formats>=1.6.1, text, time, pipes-safe,
                         exceptions, pipes, bytestring, filepath, yaml, aeson, directory, parsec,
-                        vector, pipes-ordered-zip, table-layout, mtl,
+                        vector, pipes-ordered-zip, table-layout, mtl, githash,
                         cassava, pureMD5,
                         yaml-pretty-extras >= 0.0.2.2, http-conduit, conduit, http-types, zip-archive,
                         unordered-containers, network-uri, optparse-applicative, co-log, regex-tdfa,

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -29,7 +29,7 @@ library
                         cassava, pureMD5,
                         yaml-pretty-extras >= 0.0.2.2, http-conduit, conduit, http-types, zip-archive,
                         unordered-containers, network-uri, optparse-applicative, co-log, regex-tdfa,
-                        scientific, country
+                        scientific, country, containers
     default-language:   Haskell2010
 
 executable trident

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -12,6 +12,8 @@ import           Poseidon.CLI.Init                       (InitOptions (..),
 import           Poseidon.CLI.List                       (ListOptions (..),
                                                           runList)
 import           Poseidon.CLI.OptparseApplicativeParsers
+import           Poseidon.CLI.Snapshot                   (SnapshotOptions (..),
+                                                          runSnapshot)
 import           Poseidon.CLI.Summarise                  (SummariseOptions (..),
                                                           runSummarise)
 import           Poseidon.CLI.Survey                     (SurveyOptions (..),
@@ -29,7 +31,6 @@ import           Poseidon.Utils                          (LogMode (..),
                                                           PoseidonIO, logError,
                                                           renderPoseidonException,
                                                           usePoseidonLogger)
-import Poseidon.CLI.Snapshot (SnapshotOptions (..), runSnapshot)
 
 import           Control.Applicative                     ((<|>))
 import           Control.Exception                       (catch)

--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -223,6 +223,6 @@ validateOptParser = ValidateOptions <$> parseBasePaths
 
 snapshotOptParser :: OP.Parser SnapshotOptions
 snapshotOptParser = SnapshotOptions <$> parseBasePaths
-                                    <*> parseSnapOutDir
+                                    <*> parseSnapOperation
                                     <*> parseSnapWithGit
                                     <*> parseMinimalOutput

--- a/src/Poseidon/CLI/OptparseApplicativeParsers.hs
+++ b/src/Poseidon/CLI/OptparseApplicativeParsers.hs
@@ -26,19 +26,27 @@ import           System.FilePath         (dropExtension, takeExtension, (<.>))
 import           Text.Read               (readMaybe)
 
 parseSnapOperation :: OP.Parser SnapOperation
-parseSnapOperation = (CreateSnap <$> parseSnapOutDir) <|> (UpdateSnap <$> parseSnapUpdate)
+parseSnapOperation = (CreateSnap <$> parseSnapOutPath) <|> (UpdateSnap <$> parseSnapUpdatePath <*> parseSnapMaybeOutPath)
 
-parseSnapOutDir :: OP.Parser FilePath
-parseSnapOutDir = OP.strOption (OP.long "outFile" <>
+parseSnapOutPath :: OP.Parser FilePath
+parseSnapOutPath = OP.strOption (OP.long "outFile" <>
     OP.short 'o' <>
     OP.metavar "PATH" <>
     OP.help "Path to the resulting snapshot definition file.")
 
-parseSnapUpdate :: OP.Parser FilePath
-parseSnapUpdate = OP.strOption (OP.long "updateFile" <>
+parseSnapUpdatePath :: OP.Parser FilePath
+parseSnapUpdatePath = OP.strOption (OP.long "updateFile" <>
     OP.short 'u' <>
     OP.metavar "PATH" <>
     OP.help "Path to the snapshot definition file that should be updated.")
+
+parseSnapMaybeOutPath :: OP.Parser (Maybe FilePath)
+parseSnapMaybeOutPath = OP.option (Just <$> OP.str) (
+    OP.short 'o' <>
+    OP.long "updateOutFile" <>
+    OP.help "If this is set, then the input snapshot file will not be overwritten, but a new file will be created instead." <>
+    OP.value Nothing
+    )
 
 parseSnapWithGit :: OP.Parser Bool
 parseSnapWithGit = OP.switch (OP.long "withGit" <> OP.help "Should the resulting snapshot file include git commit hashes (local head)?")

--- a/src/Poseidon/CLI/OptparseApplicativeParsers.hs
+++ b/src/Poseidon/CLI/OptparseApplicativeParsers.hs
@@ -16,7 +16,7 @@ import           Poseidon.SecondaryTypes (ContributorSpec (..),
                                           contributorSpecParser,
                                           poseidonVersionParser, runParser)
 import           Poseidon.Utils          (LogMode (..))
-
+import Poseidon.CLI.Snapshot (SnapOperation (..))
 
 import           Control.Applicative     ((<|>))
 import           Data.Version            (Version)
@@ -25,11 +25,20 @@ import           SequenceFormats.Plink   (PlinkPopNameMode (PlinkPopNameAsBoth, 
 import           System.FilePath         (dropExtension, takeExtension, (<.>))
 import           Text.Read               (readMaybe)
 
+parseSnapOperation :: OP.Parser SnapOperation
+parseSnapOperation = (CreateSnap <$> parseSnapOutDir) <|> (UpdateSnap <$> parseSnapUpdate)
+
 parseSnapOutDir :: OP.Parser FilePath
-parseSnapOutDir = OP.strOption (OP.long "outDir" <>
+parseSnapOutDir = OP.strOption (OP.long "outFile" <>
     OP.short 'o' <>
-    OP.metavar "DIR" <>
-    OP.help "Directory where the resulting POSEIDON_SNAPSHOT.yml should be written.")
+    OP.metavar "PATH" <>
+    OP.help "Path to the resulting snapshot definition file.")
+
+parseSnapUpdate :: OP.Parser FilePath
+parseSnapUpdate = OP.strOption (OP.long "updateFile" <>
+    OP.short 'u' <>
+    OP.metavar "PATH" <>
+    OP.help "Path to the snapshot definition file that should be updated.")
 
 parseSnapWithGit :: OP.Parser Bool
 parseSnapWithGit = OP.switch (OP.long "withGit" <> OP.help "Should the resulting snapshot file include git commit hashes (local head)?")

--- a/src/Poseidon/CLI/OptparseApplicativeParsers.hs
+++ b/src/Poseidon/CLI/OptparseApplicativeParsers.hs
@@ -4,6 +4,7 @@ module Poseidon.CLI.OptparseApplicativeParsers where
 
 import           Poseidon.CLI.List       (ListEntity (..),
                                           RepoLocationSpec (..))
+import           Poseidon.CLI.Snapshot   (SnapOperation (..))
 import           Poseidon.EntitiesList   (EntitiesList, EntityInput (..),
                                           PoseidonEntity, SignedEntitiesList,
                                           SignedEntity, readEntitiesFromString)
@@ -16,7 +17,6 @@ import           Poseidon.SecondaryTypes (ContributorSpec (..),
                                           contributorSpecParser,
                                           poseidonVersionParser, runParser)
 import           Poseidon.Utils          (LogMode (..))
-import Poseidon.CLI.Snapshot (SnapOperation (..))
 
 import           Control.Applicative     ((<|>))
 import           Data.Version            (Version)

--- a/src/Poseidon/CLI/OptparseApplicativeParsers.hs
+++ b/src/Poseidon/CLI/OptparseApplicativeParsers.hs
@@ -25,6 +25,15 @@ import           SequenceFormats.Plink   (PlinkPopNameMode (PlinkPopNameAsBoth, 
 import           System.FilePath         (dropExtension, takeExtension, (<.>))
 import           Text.Read               (readMaybe)
 
+parseSnapOutDir :: OP.Parser FilePath
+parseSnapOutDir = OP.strOption (OP.long "outDir" <>
+    OP.short 'o' <>
+    OP.metavar "DIR" <>
+    OP.help "Directory where the resulting POSEIDON_SNAPSHOT.yml should be written.")
+
+parseSnapWithGit :: OP.Parser Bool
+parseSnapWithGit = OP.switch (OP.long "withGit" <> OP.help "Should the resulting snapshot file include git commit hashes (local head)?")
+
 parsePoseidonVersion :: OP.Parser (Maybe Version)
 parsePoseidonVersion = OP.option (Just <$> OP.eitherReader readPoseidonVersionString) (
     OP.long "poseidonVersion" <>
@@ -345,9 +354,9 @@ parseMaybeOutPackageName = OP.option (Just <$> OP.str) (
     OP.value Nothing
     )
 
-parseMakeMinimalPackage :: OP.Parser Bool
-parseMakeMinimalPackage = OP.switch (OP.long "minimal" <>
-    OP.help "should only a minimal output package be created?")
+parseMinimalOutput :: OP.Parser Bool
+parseMinimalOutput = OP.switch (OP.long "minimal" <>
+    OP.help "Should the output data be reduced to a necessary minimum and omit empty scaffolding?")
 
 parseOutOnlyGeno :: OP.Parser Bool
 parseOutOnlyGeno = OP.switch (OP.long "onlyGeno" <>

--- a/src/Poseidon/CLI/Snapshot.hs
+++ b/src/Poseidon/CLI/Snapshot.hs
@@ -1,2 +1,35 @@
 module Poseidon.CLI.Snapshot where
 
+import           Poseidon.Package       (PackageReadOptions (..),
+                                         PoseidonPackage (..),
+                                         defaultPackageReadOptions,
+                                         readPoseidonPackageCollection)
+import           Poseidon.Utils         (PoseidonIO)
+import Poseidon.Snapshot (makeSnapshot, SnapshotMode (..), writeSnapshot, makeMinimalSnapshot)
+
+-- | A datatype representing command line options for the summarise command
+data SnapshotOptions = SnapshotOptions
+    { _snapshotBaseDirs        :: [FilePath]
+    , _snapshotOutputDirectory :: FilePath
+    , _snapshotWithGitCommits  :: Bool
+    , _snapshotMinimal         :: Bool
+    }
+
+pacReadOpts :: PackageReadOptions
+pacReadOpts = defaultPackageReadOptions {
+      _readOptStopOnDuplicates = False
+    , _readOptIgnoreChecksums  = True
+    , _readOptIgnoreGeno       = True
+    , _readOptGenoCheck        = False
+    }
+
+-- | The main function running the janno command
+runSnapshot :: SnapshotOptions -> PoseidonIO ()
+runSnapshot (SnapshotOptions baseDirs outDir withGit minimal) = do
+    allPackages <- readPoseidonPackageCollection pacReadOpts baseDirs
+    let modeSetting = if withGit then SnapshotWithGit else SimpleSnapshot
+    snapshot <- if minimal
+                then do makeMinimalSnapshot modeSetting allPackages
+                else do makeSnapshot modeSetting allPackages
+    writeSnapshot outDir snapshot
+

--- a/src/Poseidon/CLI/Snapshot.hs
+++ b/src/Poseidon/CLI/Snapshot.hs
@@ -10,10 +10,12 @@ import           Poseidon.Utils    (PoseidonIO)
 -- | A datatype representing command line options for the summarise command
 data SnapshotOptions = SnapshotOptions
     { _snapshotBaseDirs        :: [FilePath]
-    , _snapshotOutputDirectory :: FilePath
+    , _snapshotOperation       :: SnapOperation
     , _snapshotWithGitCommits  :: Bool
     , _snapshotMinimal         :: Bool
     }
+
+data SnapOperation = CreateSnap FilePath | UpdateSnap FilePath
 
 pacReadOpts :: PackageReadOptions
 pacReadOpts = defaultPackageReadOptions {
@@ -25,11 +27,14 @@ pacReadOpts = defaultPackageReadOptions {
 
 -- | The main function running the janno command
 runSnapshot :: SnapshotOptions -> PoseidonIO ()
-runSnapshot (SnapshotOptions baseDirs outDir withGit minimal) = do
+runSnapshot (SnapshotOptions baseDirs operation withGit minimal) = do
     allPackages <- readPoseidonPackageCollection pacReadOpts baseDirs
     let modeSetting = if withGit then SnapshotWithGit else SimpleSnapshot
     snapshot <- if minimal
                 then do makeMinimalSnapshot modeSetting allPackages
                 else do makeSnapshot modeSetting allPackages
-    writeSnapshot outDir snapshot
+    case operation of
+        CreateSnap p -> writeSnapshot p snapshot
+        UpdateSnap p -> error "huhu"
+    
 

--- a/src/Poseidon/CLI/Snapshot.hs
+++ b/src/Poseidon/CLI/Snapshot.hs
@@ -2,17 +2,18 @@ module Poseidon.CLI.Snapshot where
 
 import           Poseidon.Package  (PackageReadOptions (..),
                                     defaultPackageReadOptions,
-                                    readPoseidonPackageCollection, PoseidonException (PoseidonEmptyForgeException))
+                                    readPoseidonPackageCollection)
 import           Poseidon.Snapshot (SnapshotMode (..), makeMinimalSnapshot,
-                                    makeSnapshot, writeSnapshot, readSnapshot)
+                                    makeSnapshot, readSnapshot, updateSnapshot,
+                                    writeSnapshot)
 import           Poseidon.Utils    (PoseidonIO)
 
 -- | A datatype representing command line options for the summarise command
 data SnapshotOptions = SnapshotOptions
-    { _snapshotBaseDirs        :: [FilePath]
-    , _snapshotOperation       :: SnapOperation
-    , _snapshotWithGitCommits  :: Bool
-    , _snapshotMinimal         :: Bool
+    { _snapshotBaseDirs       :: [FilePath]
+    , _snapshotOperation      :: SnapOperation
+    , _snapshotWithGitCommits :: Bool
+    , _snapshotMinimal        :: Bool
     }
 
 data SnapOperation = CreateSnap FilePath | UpdateSnap FilePath (Maybe FilePath)
@@ -37,9 +38,7 @@ runSnapshot (SnapshotOptions baseDirs operation withGit minimal) = do
         CreateSnap outPath -> writeSnapshot outPath newSnapshot
         UpdateSnap inPath maybeOutPath -> do
             oldSnapshot <- readSnapshot inPath
-            updatedSnapshot <- updateSnapshot oldSnapshot newSnapshot
+            let updatedSnapshot = updateSnapshot oldSnapshot newSnapshot
             case maybeOutPath of
                 Nothing      -> writeSnapshot inPath updatedSnapshot
                 Just outPath -> writeSnapshot outPath updatedSnapshot
-
-updateSnapshot = undefined

--- a/src/Poseidon/CLI/Snapshot.hs
+++ b/src/Poseidon/CLI/Snapshot.hs
@@ -1,11 +1,12 @@
 module Poseidon.CLI.Snapshot where
 
-import           Poseidon.Package       (PackageReadOptions (..),
-                                         PoseidonPackage (..),
-                                         defaultPackageReadOptions,
-                                         readPoseidonPackageCollection)
-import           Poseidon.Utils         (PoseidonIO)
-import Poseidon.Snapshot (makeSnapshot, SnapshotMode (..), writeSnapshot, makeMinimalSnapshot)
+import           Poseidon.Package  (PackageReadOptions (..),
+                                    PoseidonPackage (..),
+                                    defaultPackageReadOptions,
+                                    readPoseidonPackageCollection)
+import           Poseidon.Snapshot (SnapshotMode (..), makeMinimalSnapshot,
+                                    makeSnapshot, writeSnapshot)
+import           Poseidon.Utils    (PoseidonIO)
 
 -- | A datatype representing command line options for the summarise command
 data SnapshotOptions = SnapshotOptions

--- a/src/Poseidon/CLI/Snapshot.hs
+++ b/src/Poseidon/CLI/Snapshot.hs
@@ -1,7 +1,6 @@
 module Poseidon.CLI.Snapshot where
 
 import           Poseidon.Package  (PackageReadOptions (..),
-                                    PoseidonPackage (..),
                                     defaultPackageReadOptions,
                                     readPoseidonPackageCollection)
 import           Poseidon.Snapshot (SnapshotMode (..), makeMinimalSnapshot,

--- a/src/Poseidon/CLI/Snapshot.hs
+++ b/src/Poseidon/CLI/Snapshot.hs
@@ -1,0 +1,2 @@
+module Poseidon.CLI.Snapshot where
+

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -21,7 +21,8 @@ module Poseidon.Package (
     defaultPackageReadOptions,
     readPoseidonPackage,
     makePseudoPackageFromGenotypeData,
-    getJannoRowsFromPac
+    getJannoRowsFromPac,
+    dummyContributor
 ) where
 
 import           Poseidon.BibFile           (BibEntry (..), BibTeX,
@@ -702,6 +703,13 @@ makePseudoPackageFromGenotypeData (GenotypeDataSpec format_ genoFile_ _ snpFile_
                then baseDirGeno
                else throwM $ PoseidonUnequalBaseDirException g s i
 
+dummyContributor :: ContributorSpec
+dummyContributor =
+    ContributorSpec
+        "Josiah Carberry"
+        "carberry@brown.edu"
+        (Just $ ORCID {_orcidNums = "000000021825009", _orcidChecksum = '7'})
+
 -- | A function to create a more complete POSEIDON package
 -- This will take only the filenames of the provided files, so it assumes that the files will be copied into
 -- the directory into which the YAML file will be written
@@ -718,12 +726,7 @@ newPackageTemplate baseDir name genoData indsOrJanno seqSource bib = do
     let minimalTemplate = newMinimalPackageTemplate baseDir name genoData
         fluffedUpTemplate = minimalTemplate {
             posPacDescription = Just "Empty package template. Please add a description"
-        ,   posPacContributor = [
-                ContributorSpec
-                    "Josiah Carberry"
-                    "carberry@brown.edu"
-                    (Just $ ORCID {_orcidNums = "000000021825009", _orcidChecksum = '7'})
-                ]
+        ,   posPacContributor = [dummyContributor]
         ,   posPacPackageVersion = Just $ makeVersion [0, 1, 0]
         ,   posPacLastModified = Just today
         }

--- a/src/Poseidon/Snapshot.hs
+++ b/src/Poseidon/Snapshot.hs
@@ -1,0 +1,1 @@
+module Poseidon.Snapshot where

--- a/src/Poseidon/Snapshot.hs
+++ b/src/Poseidon/Snapshot.hs
@@ -87,7 +87,7 @@ instance ToJSON PackageState where
 data SnapshotMode = SimpleSnapshot | SnapshotWithGit
 
 writeSnapshot :: FilePath -> PoseidonPackageSnapshot -> PoseidonIO ()
-writeSnapshot p = encodeFilePretty (p </> "POSEIDON_SNAPSHOT.yml")
+writeSnapshot p = encodeFilePretty p
 
 makeSnapshot :: SnapshotMode -> [PoseidonPackage] -> PoseidonIO PoseidonPackageSnapshot
 makeSnapshot snapMode pacs = do

--- a/src/Poseidon/Snapshot.hs
+++ b/src/Poseidon/Snapshot.hs
@@ -5,7 +5,7 @@ module Poseidon.Snapshot where
 import           Poseidon.Package        (PoseidonPackage (..),
                                           dummyContributor)
 import           Poseidon.SecondaryTypes (ContributorSpec)
-import           Poseidon.Utils          (PoseidonIO, logDebug, logWarning)
+import           Poseidon.Utils          (PoseidonIO, logWarning)
 
 import           Control.Monad.IO.Class  (liftIO)
 import           Data.Aeson              (FromJSON, ToJSON, object, parseJSON,
@@ -13,7 +13,6 @@ import           Data.Aeson              (FromJSON, ToJSON, object, parseJSON,
                                           (.:?), (.=))
 import           Data.Time               (Day, UTCTime (..), getCurrentTime)
 import           Data.Version            (Version, makeVersion)
-import           Data.Yaml               (decodeEither')
 import           Data.Yaml.Pretty.Extras (ToPrettyYaml (..), encodeFilePretty)
 import           GitHash                 (getGitInfo, giHash)
 import           System.Directory        (makeAbsolute)
@@ -131,7 +130,7 @@ snapshotPackages snapMode = mapM snapOne
         getGitCommitHash p = do
             eitherCommit <- liftIO $ getGitInfo p
             case eitherCommit of
-                Left e -> do
+                Left _ -> do
                     pAbsolute <- liftIO $ makeAbsolute p
                     let oneLevelUp = takeDirectory pAbsolute
                     if oneLevelUp == takeDirectory oneLevelUp

--- a/src/Poseidon/Snapshot.hs
+++ b/src/Poseidon/Snapshot.hs
@@ -1,1 +1,80 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Poseidon.Snapshot where
+
+import Poseidon.SecondaryTypes (ContributorSpec)
+
+import Data.Version (Version)
+import Data.Time (Day)
+import           Data.Aeson                 (FromJSON, ToJSON, object,
+                                             parseJSON, toJSON, withObject,
+                                             (.!=), (.:), (.:?), (.=))
+import           Data.Yaml                  (decodeEither')
+import           Data.Yaml.Pretty.Extras    (ToPrettyYaml (..),
+                                             encodeFilePretty)
+
+data SnapshotYamlStruct = SnapshotYamlStruct
+    { snapYamlTitle           :: Maybe String
+    , snapYamlDescription     :: Maybe String
+    , snapYamlContributor     :: [ContributorSpec]
+    , snapYamlSnapshotVersion :: Maybe Version
+    , snapYamlLastModified    :: Maybe Day
+    , snapYamlPackages        :: [PackageStateSpec]
+    }
+    deriving (Show, Eq)
+
+instance FromJSON SnapshotYamlStruct where
+    parseJSON = withObject "PoseidonYamlStruct" $ \v -> SnapshotYamlStruct
+        <$> v .:? "title"
+        <*> v .:? "description"
+        <*> v .:? "contributor" .!= []
+        <*> v .:? "snapshotVersion"
+        <*> v .:? "lastModified"
+        <*> v .:? "packages" .!= []
+
+instance ToJSON SnapshotYamlStruct where
+    toJSON x = object $ [
+        "title"            .= snapYamlTitle x,
+        "description"      .= snapYamlDescription x] ++
+        (if not $ null (snapYamlContributor x) then ["contributor" .= snapYamlContributor x] else []) ++
+        ["snapshotVersion" .= snapYamlSnapshotVersion x,
+        "lastModified"     .= snapYamlLastModified x] ++
+        (if not $ null (snapYamlPackages x) then ["packages" .= snapYamlPackages x] else [])
+
+instance ToPrettyYaml SnapshotYamlStruct where
+    fieldOrder = const [
+        "title",
+        "description",
+        "contributor",
+        "name",
+        "email",
+        "orcid",
+        "snapshotVersion",
+        "lastModified",
+        "packages",
+        "title",
+        "version",
+        "commit"
+        ]
+
+-- | A data type to represent a package state
+data PackageStateSpec = PackageStateSpec
+    { pacVerTitle   :: String -- ^ the title of the package
+    , pacVerVersion :: Version -- ^ the version of the package
+    , pacVerCommit  :: Maybe String -- ^ the hash of a relevant commit where a package can be accessed in this version
+                                    -- (only relevant) for our server-client architecture
+    }
+    deriving (Show, Eq)
+
+instance FromJSON PackageStateSpec where
+    parseJSON = withObject "packages" $ \v -> PackageStateSpec
+        <$> v .:  "title"
+        <*> v .:  "version"
+        <*> v .:? "commit"
+
+instance ToJSON PackageStateSpec where
+    toJSON x = object [
+          "title"    .= pacVerTitle x
+        , "version" .= pacVerVersion x
+        , "commit"  .= pacVerCommit x
+        ]

--- a/src/Poseidon/Snapshot.hs
+++ b/src/Poseidon/Snapshot.hs
@@ -3,28 +3,32 @@
 module Poseidon.Snapshot where
 
 import Poseidon.SecondaryTypes (ContributorSpec)
+import Poseidon.Package (PoseidonPackage (..), dummyContributor)
+import Poseidon.Utils (PoseidonIO, logDebug, logWarning)
 
-import Data.Version (Version)
-import Data.Time (Day)
+import Data.Version (Version, makeVersion)
+import Data.Time (Day, UTCTime (..), getCurrentTime)
 import           Data.Aeson                 (FromJSON, ToJSON, object,
                                              parseJSON, toJSON, withObject,
                                              (.!=), (.:), (.:?), (.=))
 import           Data.Yaml                  (decodeEither')
 import           Data.Yaml.Pretty.Extras    (ToPrettyYaml (..),
                                              encodeFilePretty)
+import GitHash (getGitInfo, giHash)
+import           Control.Monad.IO.Class     (liftIO)
 
-data SnapshotYamlStruct = SnapshotYamlStruct
+data PoseidonPackageSnapshot = PoseidonPackageSnapshot
     { snapYamlTitle           :: Maybe String
     , snapYamlDescription     :: Maybe String
     , snapYamlContributor     :: [ContributorSpec]
     , snapYamlSnapshotVersion :: Maybe Version
     , snapYamlLastModified    :: Maybe Day
-    , snapYamlPackages        :: [PackageStateSpec]
+    , snapYamlPackages        :: [PackageState]
     }
     deriving (Show, Eq)
 
-instance FromJSON SnapshotYamlStruct where
-    parseJSON = withObject "PoseidonYamlStruct" $ \v -> SnapshotYamlStruct
+instance FromJSON PoseidonPackageSnapshot where
+    parseJSON = withObject "PoseidonYamlStruct" $ \v -> PoseidonPackageSnapshot
         <$> v .:? "title"
         <*> v .:? "description"
         <*> v .:? "contributor" .!= []
@@ -32,7 +36,7 @@ instance FromJSON SnapshotYamlStruct where
         <*> v .:? "lastModified"
         <*> v .:? "packages" .!= []
 
-instance ToJSON SnapshotYamlStruct where
+instance ToJSON PoseidonPackageSnapshot where
     toJSON x = object $ [
         "title"            .= snapYamlTitle x,
         "description"      .= snapYamlDescription x] ++
@@ -41,7 +45,7 @@ instance ToJSON SnapshotYamlStruct where
         "lastModified"     .= snapYamlLastModified x] ++
         (if not $ null (snapYamlPackages x) then ["packages" .= snapYamlPackages x] else [])
 
-instance ToPrettyYaml SnapshotYamlStruct where
+instance ToPrettyYaml PoseidonPackageSnapshot where
     fieldOrder = const [
         "title",
         "description",
@@ -58,23 +62,73 @@ instance ToPrettyYaml SnapshotYamlStruct where
         ]
 
 -- | A data type to represent a package state
-data PackageStateSpec = PackageStateSpec
-    { pacVerTitle   :: String -- ^ the title of the package
-    , pacVerVersion :: Version -- ^ the version of the package
-    , pacVerCommit  :: Maybe String -- ^ the hash of a relevant commit where a package can be accessed in this version
+data PackageState = PackageState
+    { pacStateTitle   :: String -- ^ the title of the package
+    , pacStateVersion :: Maybe Version -- ^ the version of the package
+    , pacStateCommit  :: Maybe String -- ^ the hash of a relevant commit where a package can be accessed in this version
                                     -- (only relevant) for our server-client architecture
     }
     deriving (Show, Eq)
 
-instance FromJSON PackageStateSpec where
-    parseJSON = withObject "packages" $ \v -> PackageStateSpec
+instance FromJSON PackageState where
+    parseJSON = withObject "packages" $ \v -> PackageState
         <$> v .:  "title"
-        <*> v .:  "version"
+        <*> v .:? "version"
         <*> v .:? "commit"
 
-instance ToJSON PackageStateSpec where
+instance ToJSON PackageState where
     toJSON x = object [
-          "title"    .= pacVerTitle x
-        , "version" .= pacVerVersion x
-        , "commit"  .= pacVerCommit x
+          "title"   .= pacStateTitle x
+        , "version" .= pacStateVersion x
+        , "commit"  .= pacStateCommit x
         ]
+
+data SnapshotMode = Simple | WithGit
+
+makeSnapshot :: SnapshotMode -> [PoseidonPackage] -> PoseidonIO PoseidonPackageSnapshot
+makeSnapshot snapMode pacs = do
+    snap <- makeMinimalSnapshot snapMode pacs
+    (UTCTime today _) <- liftIO getCurrentTime
+    return $ snap {
+      snapYamlTitle           = Just "Snapshot title"
+    , snapYamlDescription     = Just "Snapshot description"
+    , snapYamlContributor     = [dummyContributor]
+    , snapYamlSnapshotVersion = Just $ makeVersion [0, 1, 0]
+    , snapYamlLastModified    = Just today
+    }
+
+makeMinimalSnapshot :: SnapshotMode -> [PoseidonPackage] -> PoseidonIO PoseidonPackageSnapshot
+makeMinimalSnapshot snapMode pacs = do
+    pacSnapshots <- snapshotPackages snapMode pacs
+    return $ PoseidonPackageSnapshot {
+      snapYamlTitle           = Nothing
+    , snapYamlDescription     = Nothing
+    , snapYamlContributor     = []
+    , snapYamlSnapshotVersion = Nothing
+    , snapYamlLastModified    = Nothing
+    , snapYamlPackages        = pacSnapshots
+    }
+
+snapshotPackages :: SnapshotMode -> [PoseidonPackage] -> PoseidonIO [PackageState]
+snapshotPackages snapMode = mapM snapOne
+    where
+        snapOne :: PoseidonPackage -> PoseidonIO PackageState
+        snapOne pac = do
+            commit <- case snapMode of
+                Simple -> do return Nothing
+                WithGit -> do getGitCommitHash $ posPacBaseDir pac
+            return $ PackageState {
+                pacStateTitle   = posPacTitle pac,
+                pacStateVersion = posPacPackageVersion pac,
+                pacStateCommit  = commit
+            }
+        getGitCommitHash :: FilePath -> PoseidonIO (Maybe String)
+        getGitCommitHash p = do
+            eitherCommit <- liftIO $ getGitInfo p
+            case eitherCommit of
+                Left e -> do
+                    logWarning $ show e
+                    return Nothing
+                Right info -> do
+                    return $ Just $ giHash info
+

--- a/src/Poseidon/Snapshot.hs
+++ b/src/Poseidon/Snapshot.hs
@@ -2,22 +2,22 @@
 
 module Poseidon.Snapshot where
 
-import Poseidon.SecondaryTypes (ContributorSpec)
-import Poseidon.Package (PoseidonPackage (..), dummyContributor)
-import Poseidon.Utils (PoseidonIO, logDebug, logWarning)
+import           Poseidon.Package        (PoseidonPackage (..),
+                                          dummyContributor)
+import           Poseidon.SecondaryTypes (ContributorSpec)
+import           Poseidon.Utils          (PoseidonIO, logDebug, logWarning)
 
-import Data.Version (Version, makeVersion)
-import Data.Time (Day, UTCTime (..), getCurrentTime)
-import           Data.Aeson                 (FromJSON, ToJSON, object,
-                                             parseJSON, toJSON, withObject,
-                                             (.!=), (.:), (.:?), (.=))
-import           Data.Yaml                  (decodeEither')
-import           Data.Yaml.Pretty.Extras    (ToPrettyYaml (..),
-                                             encodeFilePretty)
-import GitHash (getGitInfo, giHash)
-import           Control.Monad.IO.Class     (liftIO)
-import System.FilePath ((</>), takeDirectory)
-import System.Directory (makeAbsolute)
+import           Control.Monad.IO.Class  (liftIO)
+import           Data.Aeson              (FromJSON, ToJSON, object, parseJSON,
+                                          toJSON, withObject, (.!=), (.:),
+                                          (.:?), (.=))
+import           Data.Time               (Day, UTCTime (..), getCurrentTime)
+import           Data.Version            (Version, makeVersion)
+import           Data.Yaml               (decodeEither')
+import           Data.Yaml.Pretty.Extras (ToPrettyYaml (..), encodeFilePretty)
+import           GitHash                 (getGitInfo, giHash)
+import           System.Directory        (makeAbsolute)
+import           System.FilePath         (takeDirectory, (</>))
 
 data PoseidonPackageSnapshot = PoseidonPackageSnapshot
     { snapYamlTitle           :: Maybe String


### PR DESCRIPTION
First draft of `trident snapshot` -- as discussed. Allows to create, write, read and update snapshot files.

I would like to use the `--update` + `--withGit` functionality to automatically document which package version should be downloaded from which Git commit.

At this point everything is implemented and should work. I'll write some tests to see if it really behaves as expected. And then we'll see if further changes are necessary for the special server management application.