### PR TITLE
Jannocoalesce minor adjustments

### DIFF
--- a/src/Poseidon/CLI/Jannocoalesce.hs
+++ b/src/Poseidon/CLI/Jannocoalesce.hs
@@ -9,7 +9,7 @@ import           Poseidon.Package       (PackageReadOptions (..),
                                          getJointJanno,
                                          readPoseidonPackageCollection)
 import           Poseidon.Utils         (PoseidonException (..), PoseidonIO,
-                                         logInfo, logDebug)
+                                         logDebug, logInfo)
 
 import           Control.Monad          (filterM, forM, forM_)
 import           Control.Monad.Catch    (MonadThrow, throwM)

--- a/src/Poseidon/CLI/Jannocoalesce.hs
+++ b/src/Poseidon/CLI/Jannocoalesce.hs
@@ -59,7 +59,8 @@ runJannocoalesce (JannoCoalesceOptions sourceSpec target outSpec fields overwrit
         writeJannoFile outPath (JannoRows newJanno)
 
 makeNewJannoRows :: [JannoRow] -> [JannoRow] -> [String] -> Bool -> String -> String -> Maybe String -> PoseidonIO [JannoRow]
-makeNewJannoRows sourceRows targetRows fields overwrite sKey tKey maybeStrip =
+makeNewJannoRows sourceRows targetRows fields overwrite sKey tKey maybeStrip = do
+    logInfo "Starting to coalesce..."
     forM targetRows $ \targetRow -> do
         posId <- getKeyFromJanno targetRow tKey
         sourceRowCandidates <- filterM (\r -> (matchWithOptionalStrip maybeStrip posId) <$> getKeyFromJanno r sKey) sourceRows

--- a/src/Poseidon/CLI/OptparseApplicativeParsers.hs
+++ b/src/Poseidon/CLI/OptparseApplicativeParsers.hs
@@ -775,7 +775,7 @@ parseJannocoalSourceSpec = parseJannocoalSingleSource <|> (JannoSourceBaseDirs <
         OP.long "sourceFile" <>
         OP.short 's' <>
         OP.metavar "FILE" <>
-        OP.help "The source Janno file"
+        OP.help "The source .janno file."
         )
 
 parseJannocoalTargetFile :: OP.Parser FilePath
@@ -783,7 +783,7 @@ parseJannocoalTargetFile = OP.strOption (
     OP.long "targetFile" <>
     OP.short 't' <>
     OP.metavar "FILE" <>
-    OP.help "The target file to fill"
+    OP.help "The target .janno file to fill."
     )
 
 parseJannocoalOutSpec :: OP.Parser (Maybe FilePath)
@@ -793,30 +793,47 @@ parseJannocoalOutSpec = OP.option (Just <$> OP.str) (
     OP.metavar "FILE" <>
     OP.value Nothing <>
     OP.showDefault <>
-    OP.help "An optional file to write the results to. If not specified, change the target file in place."
+    OP.help "An optional file to write the results to. \
+            \If not specified, change the target file in place."
     )
 
 parseJannocoalFillColumns :: OP.Parser [String]
 parseJannocoalFillColumns = OP.option (splitOn "," <$> OP.str) (
     OP.long "fillColumns" <>
     OP.value [] <>
-    OP.help "A comma-separated list of Janno field names. If not specified, fill all columns that can be found in the source and target."
+    OP.help "A comma-separated list of .janno field names. \
+            \If not specified, fill all columns that can be found in the source and target."
     )
 
 parseJannocoalOverride :: OP.Parser Bool
 parseJannocoalOverride = OP.switch (
     OP.long "force" <>
     OP.short 'f' <>
-    OP.help "With this option, potential non-missing content in target columns gets overridden with non-missing content in source columns. By default, only missing data gets filled-in."
+    OP.help "With this option, potential non-missing content in target columns gets overridden \
+            \with non-missing content in source columns. By default, only missing data gets filled-in."
     )
 
 parseJannocoalSourceKey :: OP.Parser String
-parseJannocoalSourceKey = OP.strOption (OP.long "sourceKey" <> OP.help "the janno column to use as the source key" <> OP.value "Poseidon_ID" <> OP.showDefault)
+parseJannocoalSourceKey = OP.strOption (
+    OP.long "sourceKey" <>
+    OP.help "The .janno column to use as the source key." <>
+    OP.value "Poseidon_ID" <>
+    OP.showDefault
+    )
 
 parseJannocoalTargetKey :: OP.Parser String
-parseJannocoalTargetKey = OP.strOption (OP.long "targetKey" <> OP.help "the janno column to use as the target key" <> OP.value "Poseidon_ID" <> OP.showDefault)
+parseJannocoalTargetKey = OP.strOption (
+    OP.long "targetKey" <>
+    OP.help "The .janno column to use as the target key." <>
+    OP.value "Poseidon_ID" <>
+    OP.showDefault
+    )
 
 parseJannocoalIdStripRegex :: OP.Parser (Maybe String)
-parseJannocoalIdStripRegex = OP.option (Just <$> OP.str) (OP.long "stripIdSuffix" <>
-    OP.help "an optional regular expression to identify parts of the IDs to strip before matching between source and target" <> OP.value Nothing)
+parseJannocoalIdStripRegex = OP.option (Just <$> OP.str) (
+    OP.long "stripIdRegex" <>
+    OP.help "An optional regular expression to identify parts of the IDs to strip \
+            \before matching between source and target. Uses POSIX Extended regular expressions." <>
+    OP.value Nothing
+    )
 


### PR DESCRIPTION
As suggested:

- moved `-- no changes` and `-- copied` to `logDebug`
- added reporting for mismatches, so targets that are not found in the source
- renamed `--stripIdSuffix` to `--stripIdRegex`
- added `Uses POSIX Extended regular expressions.` to the documentation of  `-stripIdRegex`

The rest are cosmetic changes to make code and output more consistent with other parts of trident.

Here's how the output can look now:

```
$ trident jannocoalesce -s ../../community-archive/2021_CarlhoffNature/2021_CarlhoffNature.janno -t 2021_CarlhoffNature.janno --stripIdRegex "_SG_MNT" --debug
trident v1.4.1.0 for poseidon v2.5.0, v2.6.0, v2.7.0, v2.7.1
https://poseidon-framework.github.io

[Debug]   [2023-12-20 13:13:44] Reading: ../../community-archive/2021_CarlhoffNature/2021_CarlhoffNature.janno
[Debug]   [2023-12-20 13:13:44] 1 samples in this file
[Debug]   [2023-12-20 13:13:44] Reading: 2021_CarlhoffNature.janno
[Debug]   [2023-12-20 13:13:44] 6 samples in this file
[Debug]   [2023-12-20 13:13:44] Additional columns: Eager_ID (?), Main_ID (?), RateErrX (?), RateErrY (?), RateX (?), RateY (?)
[Info]    [2023-12-20 13:13:44] Starting to coalesce...
[Info]    [2023-12-20 13:13:44] matched target GUP001_SG_MNT with source GUP001
[Debug]   [2023-12-20 13:13:44] -- no changes
[Info]    [2023-12-20 13:13:44] no match for target GUP001_TF_MNT in source
[Info]    [2023-12-20 13:13:44] no match for target GUP001_MNT in source
[Info]    [2023-12-20 13:13:44] no match for target GUP001_SG_ss_MNT in source
[Info]    [2023-12-20 13:13:44] no match for target GUP001_TF_ss_MNT in source
[Info]    [2023-12-20 13:13:44] no match for target GUP001_ss_MNT in source
[Info]    [2023-12-20 13:13:44] Writing to file (directory will be created if missing): 2021_CarlhoffNature.janno
```

I think we should slowly stop to talk about "individuals" when we refer to .janno rows. This will be a long and slow process, but we should to become more clear in the terminology here.