### PR TITLE
Retiring Josiah Carberry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,3 @@
-# taken from https://vrom911.github.io/blog/github-actions-releases
-
 name: Release
 
 on:
@@ -23,14 +21,13 @@ jobs:
           name: Release ${{ github.ref_name }}
           draft: true
 
-  build_linux_artifact:
+  build_normal_artifacts:
     needs: [create_release]
-    name: ${{ matrix.os }}/GHC ${{ matrix.ghc }}/${{ github.ref_name }}
+    name: ${{ matrix.os }}/${{ github.ref }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04] # old version is on purpose: to compile with old libc
-        ghc: ["9.4.7"]
+        os: [ubuntu-20.04, macOS-latest, windows-latest]
 
     steps:
       - name: Check out code
@@ -43,27 +40,24 @@ jobs:
           tagRegex: "v(.*)"
           tagRegexGroup: 1
 
-      - name: Setup Haskell
-        uses: haskell-actions/setup@v2
-        id: setup-haskell-cabal
+      - name: Build executable
+        uses: freckle/stack-action@v5
+        id: stack
         with:
-          ghc-version: ${{ matrix.ghc }}
-
-      - name: Freeze
-        run: cabal freeze
-
-      - name: Build
-        run: |
-          mkdir dist
-          cabal install exe:trident --install-method=copy --overwrite-policy=always --installdir=dist -fembed_data_files
+          stack-arguments: --copy-bins
 
       - name: Set binary path name
         id: binarypath
         run: |
-          currentEXE="./dist/trident"
-          newEXE="trident-$RUNNER_OS"
-          mv $currentEXE $newEXE
-          echo "BINARY_PATH=$newEXE" >> $GITHUB_OUTPUT
+             if [ "$RUNNER_OS" == "Windows" ]; then
+                 newEXE="trident-$RUNNER_OS.exe"
+             else
+                 newEXE="trident-$RUNNER_OS"
+             fi
+             currentEXE="${{ steps.stack.outputs.local-bin }}/trident"
+             mv $currentEXE $newEXE
+             echo "BINARY_PATH=$newEXE" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Compress binary
         uses: svenstaro/upx-action@v2
@@ -81,126 +75,6 @@ jobs:
           artifacts: ${{ steps.binarypath.outputs.BINARY_PATH }}
           artifactContentType: application/octet-stream
 
-  build_mac_artifact:
-    needs: [create_release]
-    name: ${{ matrix.os }}/GHC ${{ matrix.ghc }}/${{ github.ref_name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macOS-latest]
-        ghc: ["9.4.7"]
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set tag name
-        uses: olegtarasov/get-tag@v2.1
-        id: tagName
-        with:
-          tagRegex: "v(.*)"
-          tagRegexGroup: 1
-
-      - name: Install pkgconfig (for the dependency "digest")
-        run: brew install pkg-config
-
-      - name: Setup Haskell
-        uses: haskell-actions/setup@v2
-        id: setup-haskell-cabal
-        with:
-          ghc-version: ${{ matrix.ghc }}
-
-      - name: Freeze
-        run: |
-          : # simdutf doesn't build on macOS any more, so we need to set a flag to ignore it when building the text package
-          cabal freeze --constraint="any.text >= 2.0.1" --constraint="any.text -simdutf"
-
-      - name: Build
-        run: |
-          mkdir dist
-          cabal install exe:trident --install-method=copy --overwrite-policy=always --installdir=dist -fembed_data_files
-
-      - name: Set binary path name
-        id: binarypath
-        run: |
-          currentEXE="./dist/trident"
-          newEXE="trident-$RUNNER_OS"
-          mv $currentEXE $newEXE
-          echo "BINARY_PATH=$newEXE" >> $GITHUB_OUTPUT
-
-      - name: Compress binary
-        uses: svenstaro/upx-action@v2
-        with:
-          files: ${{ steps.binarypath.outputs.BINARY_PATH }}
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: ncipollo/release-action@v1
-        with:
-          name: Release ${{ github.ref_name }}
-          draft: true
-          allowUpdates: true
-          artifactErrorsFailBuild: true
-          artifacts: ${{ steps.binarypath.outputs.BINARY_PATH }}
-          artifactContentType: application/octet-stream
-
-  build_windows_artifact:
-    needs: [create_release]
-    name: ${{ matrix.os }}/GHC ${{ matrix.ghc }}/${{ github.ref_name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest]
-        ghc: ["9.4.7"]
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set tag name
-        uses: olegtarasov/get-tag@v2.1
-        id: tagName
-        with:
-          tagRegex: "v(.*)"
-          tagRegexGroup: 1
-
-      - name: Setup Haskell
-        uses: haskell-actions/setup@v2
-        id: setup-haskell-cabal
-        with:
-          ghc-version: ${{ matrix.ghc }}
-
-      - name: Freeze
-        run: |
-          cabal freeze
-
-      - name: Build
-        run: |
-          mkdir dist
-          cabal install exe:trident --install-method=copy --overwrite-policy=always --installdir=dist -fembed_data_files
-
-      - name: Set binary path name
-        id: binarypath
-        run: |
-          Rename-Item -Path "./dist/trident.exe" -NewName "trident-Windows.exe"
-          echo "BINARY_PATH=./dist/trident-Windows.exe" >> $env:GITHUB_OUTPUT
-
-      - name: Compress binary
-        uses: svenstaro/upx-action@v2
-        with:
-          files: ${{ steps.binarypath.outputs.BINARY_PATH }}
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: ncipollo/release-action@v1
-        with:
-          name: Release ${{ github.ref_name }}
-          draft: true
-          allowUpdates: true
-          artifactErrorsFailBuild: true
-          artifacts: ${{ steps.binarypath.outputs.BINARY_PATH }}
-          artifactContentType: application/octet-stream
-  
   build_centos_artifact:
     needs: [create_release]
     runs-on: ubuntu-latest

--- a/.github/workflows/release_backup.yml
+++ b/.github/workflows/release_backup.yml
@@ -1,0 +1,230 @@
+# taken from https://vrom911.github.io/blog/github-actions-releases
+
+name: Release
+
+#on:
+  # Trigger the workflow on the new 'v*' tag created
+#  push:
+#    tags:
+#      - "v*"
+
+jobs:
+  create_release:
+    name: Create Github Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref_name }}
+          draft: true
+
+  build_linux_artifact:
+    needs: [create_release]
+    name: ${{ matrix.os }}/GHC ${{ matrix.ghc }}/${{ github.ref_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04] # old version is on purpose: to compile with old libc
+        ghc: ["9.4.7"]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set tag name
+        uses: olegtarasov/get-tag@v2.1
+        id: tagName
+        with:
+          tagRegex: "v(.*)"
+          tagRegexGroup: 1
+
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - name: Freeze
+        run: cabal freeze
+
+      - name: Build
+        run: |
+          mkdir dist
+          cabal install exe:trident --install-method=copy --overwrite-policy=always --installdir=dist -fembed_data_files
+
+      - name: Set binary path name
+        id: binarypath
+        run: |
+          currentEXE="./dist/trident"
+          newEXE="trident-$RUNNER_OS"
+          mv $currentEXE $newEXE
+          echo "BINARY_PATH=$newEXE" >> $GITHUB_OUTPUT
+
+      - name: Compress binary
+        uses: svenstaro/upx-action@v2
+        with:
+          files: ${{ steps.binarypath.outputs.BINARY_PATH }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref_name }}
+          draft: true
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          artifacts: ${{ steps.binarypath.outputs.BINARY_PATH }}
+          artifactContentType: application/octet-stream
+
+  build_mac_artifact:
+    needs: [create_release]
+    name: ${{ matrix.os }}/GHC ${{ matrix.ghc }}/${{ github.ref_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest]
+        ghc: ["9.4.7"]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set tag name
+        uses: olegtarasov/get-tag@v2.1
+        id: tagName
+        with:
+          tagRegex: "v(.*)"
+          tagRegexGroup: 1
+
+      - name: Install pkgconfig (for the dependency "digest")
+        run: brew install pkg-config
+
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - name: Freeze
+        run: |
+          : # simdutf doesn't build on macOS any more, so we need to set a flag to ignore it when building the text package
+          cabal freeze --constraint="any.text >= 2.0.1" --constraint="any.text -simdutf"
+
+      - name: Build
+        run: |
+          mkdir dist
+          cabal install exe:trident --install-method=copy --overwrite-policy=always --installdir=dist -fembed_data_files
+
+      - name: Set binary path name
+        id: binarypath
+        run: |
+          currentEXE="./dist/trident"
+          newEXE="trident-$RUNNER_OS"
+          mv $currentEXE $newEXE
+          echo "BINARY_PATH=$newEXE" >> $GITHUB_OUTPUT
+
+      - name: Compress binary
+        uses: svenstaro/upx-action@v2
+        with:
+          files: ${{ steps.binarypath.outputs.BINARY_PATH }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref_name }}
+          draft: true
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          artifacts: ${{ steps.binarypath.outputs.BINARY_PATH }}
+          artifactContentType: application/octet-stream
+
+  build_windows_artifact:
+    needs: [create_release]
+    name: ${{ matrix.os }}/GHC ${{ matrix.ghc }}/${{ github.ref_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        ghc: ["9.4.7"]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set tag name
+        uses: olegtarasov/get-tag@v2.1
+        id: tagName
+        with:
+          tagRegex: "v(.*)"
+          tagRegexGroup: 1
+
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - name: Freeze
+        run: |
+          cabal freeze
+
+      - name: Build
+        run: |
+          mkdir dist
+          cabal install exe:trident --install-method=copy --overwrite-policy=always --installdir=dist -fembed_data_files
+
+      - name: Set binary path name
+        id: binarypath
+        run: |
+          Rename-Item -Path "./dist/trident.exe" -NewName "trident-Windows.exe"
+          echo "BINARY_PATH=./dist/trident-Windows.exe" >> $env:GITHUB_OUTPUT
+
+      - name: Compress binary
+        uses: svenstaro/upx-action@v2
+        with:
+          files: ${{ steps.binarypath.outputs.BINARY_PATH }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref_name }}
+          draft: true
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          artifacts: ${{ steps.binarypath.outputs.BINARY_PATH }}
+          artifactContentType: application/octet-stream
+  
+  build_centos_artifact:
+    needs: [create_release]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t linux -f .github/workflows/Dockerfile.centos .
+
+      - name: Create container
+        run: docker create --name linuxcontainer linux
+
+      - name: Copy executable
+        run: docker cp linuxcontainer:/root/.local/bin/trident trident-conda-linux
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref_name }}
+          draft: true
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          artifacts: trident-conda-linux
+          artifactContentType: application/octet-stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- V 1.5.0.0
+    - Removed Josiah Carberry from `newPackageTemplate`, so that he doesn't get added any more to new packages created by `init` and `forge` - the contributor field is missing in the output of these commands now.
+    - Adjusted the golden test output accordingly, but also added Josiah to one of the test packages (`test/testDat/testPackages/ancient/Schiffels_2016`) to keep him around at least in one way and make sure that the ORCID parser runs in the tests.
+    - Added a new warning to the package reading process to point out an empty contributor field.
 - V 1.4.1.0:
     - Added new tool `trident jannocoalesce`, which merges information from a source .janno file to a target .janno file.
 - V 1.4.0.4:

--- a/CHANGELOGRELEASE.md
+++ b/CHANGELOGRELEASE.md
@@ -1,3 +1,23 @@
+### V 1.5.0.0
+
+This is a minor, but technically breaking release. It removes the example contributor *Josiah Carberry* from new packages created by `trident init` and `trident forge` 
+
+Previously every package created by `init` or `forge` included an example entry in the `contributor` field of the `POSEIDON.yml` file:
+
+```yml
+- name: Josiah Carberry
+  email: carberry@brown.edu
+  orcid: 0000-0002-1825-0097
+```
+
+This served the purpose of reminding users to actually set a contributor and giving an example how to do so. To simplify scripting with Poseidon packages we now remove this slightly gimmicky default.
+
+To encourage setting the contributor field we instead introduce a reading/validation warning in case the `contributor` field is empty:
+
+```
+[Warning] Contributor missing in POSEIDON.yml file of package 2010_RasmussenNature-2.1.1
+```
+
 ### V 1.4.1.0
 
 This release adds an entirely new subcommand to merge two `.janno` files (`jannocoalesce`) and improves the error messages for broken `.janno` files.

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -1,5 +1,5 @@
 name:                poseidon-hs
-version:             1.4.1.0
+version:             1.5.0.0
 synopsis:            A package with tools for working with Poseidon Genotype Data
 description:         The tools in this package read and analyse Poseidon-formatted genotype databases, a modular system for storing genotype data from thousands of individuals.
 license:             MIT

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -23,7 +23,6 @@ module Poseidon.Package (
     readPoseidonPackage,
     makePseudoPackageFromGenotypeData,
     getJannoRowsFromPac,
-    dummyContributor,
     packagesToPackageInfos,
     getAllGroupInfo,
     validateGeno,
@@ -32,7 +31,7 @@ module Poseidon.Package (
 
 import           Poseidon.BibFile           (BibEntry (..), BibTeX,
                                              readBibTeXFile)
-import           Poseidon.Contributor       (ContributorSpec (..), ORCID (..))
+import           Poseidon.Contributor       (ContributorSpec (..))
 import           Poseidon.EntityTypes       (EntitySpec, HasNameAndVersion (..),
                                              IndividualInfo (..),
                                              IndividualInfoCollection,
@@ -685,13 +684,6 @@ makePseudoPackageFromGenotypeData (GenotypeDataSpec format_ genoFile_ _ snpFile_
                then baseDirGeno
                else throwM $ PoseidonUnequalBaseDirException g s i
 
-dummyContributor :: ContributorSpec
-dummyContributor =
-    ContributorSpec
-        "Josiah Carberry"
-        "carberry@brown.edu"
-        (Just $ ORCID {_orcidNums = "000000021825009", _orcidChecksum = '7'})
-
 -- | A function to create a more complete POSEIDON package
 -- This will take only the filenames of the provided files, so it assumes that the files will be copied into
 -- the directory into which the YAML file will be written
@@ -708,7 +700,7 @@ newPackageTemplate baseDir name genoData indsOrJanno seqSource bib = do
     let minimalTemplate = newMinimalPackageTemplate baseDir name genoData
         fluffedUpTemplate = minimalTemplate {
             posPacDescription = Just "Empty package template. Please add a description"
-        ,   posPacContributor = [dummyContributor]
+        ,   posPacContributor = []
         ,   posPacNameAndVersion = PacNameAndVersion name (Just $ makeVersion [0, 1, 0])
         ,   posPacLastModified = Just today
         }

--- a/src/Poseidon/Package.hs
+++ b/src/Poseidon/Package.hs
@@ -38,7 +38,8 @@ import           Poseidon.EntityTypes       (EntitySpec, HasNameAndVersion (..),
                                              PacNameAndVersion (..),
                                              determineRelevantPackages,
                                              isLatestInCollection,
-                                             makePacNameAndVersion, renderNameWithVersion)
+                                             makePacNameAndVersion,
+                                             renderNameWithVersion)
 import           Poseidon.GenotypeData      (GenotypeDataSpec (..), joinEntries,
                                              loadGenotypeData, loadIndividuals,
                                              printSNPCopyProgress)

--- a/test/PoseidonGoldenTests/GoldenTestCheckSumFile.txt
+++ b/test/PoseidonGoldenTests/GoldenTestCheckSumFile.txt
@@ -1,7 +1,7 @@
 Checksums for trident CLI output
 Automatically generated with: poseidon-devtools golden
 
-84017d82108c774459d47f7e9704de01 init init/Schiffels/POSEIDON.yml
+829e5415bf7a3d7508692a7fe274526b init init/Schiffels/POSEIDON.yml
 fd632717ecaf337a39cfd7a828a54e99 init init/Schiffels/Schiffels.janno
 0332344057c0c4dce2ff7176f8e1103d init init/Schiffels/geno.txt
 9edc4a757f785a8ecb59c54d16c5690a init init/Schiffels/Schiffels.bib
@@ -38,32 +38,32 @@ b46831b007c2d53a12b472484b7b00b4 genoconvert init/Wang/Wang.snp
 3c38f40efe215a047c02f4e98e0390da genoconvert init/Schiffels/geno.bed
 8538ffd971ebb12cf5ef6e338da27970 genoconvert init/Schiffels/geno.bim
 a9fcb59cb933d8f183f3c3f6fbf2e213 genoconvert init/Schiffels/geno.fam
-d0d463f313cac456c8edc69634f8bbcc rectify init/Schiffels/POSEIDON.yml
+72c7a584feefddb31f817c205355dd14 rectify init/Schiffels/POSEIDON.yml
 4aeae97cfc44b55b2a8005425d786148 rectify init/Schiffels/CHANGELOG.md
-176df2b0a0879faf70251d24630a5a81 rectify init/Schiffels/POSEIDON.yml
+925e402351afd974403402d141abe342 rectify init/Schiffels/POSEIDON.yml
 3bb396e099d5b8771a3409f5fe85d70b rectify init/Schiffels/CHANGELOG.md
-bee208c28143335a8e8674a39976b8a5 rectify init/Schiffels/POSEIDON.yml
+b9216f365108c5c5c66f78cceb2eb09a rectify init/Schiffels/POSEIDON.yml
 3bb396e099d5b8771a3409f5fe85d70b rectify init/Schiffels/CHANGELOG.md
-dded0a4fb8875c256776b41ab0f4f103 forge forge/ForgePac1/POSEIDON.yml
+2757f727e02dd6453fffe68c4c6ec4c8 forge forge/ForgePac1/POSEIDON.yml
 1286a2580e4bfbed7d804d5f3fe125f7 forge forge/ForgePac1/ForgePac1.geno
 8846333d9a1de6510f25a3816cc70fef forge forge/ForgePac1/ForgePac1.janno
 9089f5d5602937bb7713e1dc8d7a8f2d forge forge/ForgePac1/ForgePac1.ssf
 b4f71aff4fbc11594008c3811781cc43 forge forge/ForgePac1/ForgePac1.bib
 47485dc1f997a30c61cd2f72fe259013 forge forge/ForgePac2/POSEIDON.yml
 6010163f73dc9cf5185933fc7a0333df forge forge/ForgePac2/ForgePac2.bed
-fafa48015ed6b5b078bfe1eb408c6390 forge forge/ForgePac3/POSEIDON.yml
+0542b6a5a04a74237f1c1d02783c87e1 forge forge/ForgePac3/POSEIDON.yml
 7bd06bf634e6c29815a74532f696d753 forge forge/ForgePac3/ForgePac3.geno
 d817ecc64d504e1351d85996903f09b2 forge forge/ForgePac3/ForgePac3.snp
 ad8add34e464ee620bb392c00636e7f2 forge forge/ForgePac3/ForgePac3.ind
 163f0ccc70bdbb2e4274e9ba57b41c25 forge forge/ForgePac3/ForgePac3.janno
 7689c41aee5ce824e4281d3d81426c0c forge forge/ForgePac3/ForgePac3.ssf
-78f10ba5973f5cce09fe5842d262a961 forge forge/ForgePac4/POSEIDON.yml
+3dbdce00b3b4f6f16a251dfeb04b86d4 forge forge/ForgePac4/POSEIDON.yml
 f348944d864cbaa595f138b11d154248 forge forge/ForgePac4/ForgePac4.bim
 217cbb31258a3a7c9522d8dc9bda2386 forge forge/ForgePac4/ForgePac4.bed
 3001829ad782e27375a6132583c16f05 forge forge/ForgePac4/ForgePac4.fam
 271f090e79393f5d6f032c3b6a1b1773 forge forge/ForgePac4/ForgePac4.janno
 4ed49b8e5f094fef112a22c0b22c2cc9 forge forge/ForgePac4/ForgePac4.ssf
-c51e3b700adf50489ecfba3a3d7fa7a8 forge forge/ForgePac5/POSEIDON.yml
+f843f417fb4049531b7c3bd8e21dc348 forge forge/ForgePac5/POSEIDON.yml
 5a3783db28cf9da6356b3c6105564be5 forge forge/ForgePac5/ForgePac5.geno
 cf5700b1202bf447aae6197ab4ed7523 forge forge/ForgePac5/ForgePac5.janno
 ad2e307c7d7eb09d39f8e4996cd1d876 forge forge/ForgePac5/ForgePac5.ssf
@@ -95,7 +95,7 @@ c3ea6ad176514659f44ffb71291117d0 forge forge/ForgePac16/ForgePac16.janno
 d4a05cfef045648238a94a9d621cf667 chronicle chronicle/chronicle1.yml
 b43da4d5734371c0648553120f812466 timetravel timetravel/Lamnidis_2018-1.0.0/POSEIDON.yml
 8d57ce1a1ab28c0d8a5f391dd790a59c timetravel timetravel/Lamnidis_2018-1.0.1/POSEIDON.yml
-bee208c28143335a8e8674a39976b8a5 timetravel timetravel/Schiffels-1.1.1/POSEIDON.yml
+b9216f365108c5c5c66f78cceb2eb09a timetravel timetravel/Schiffels-1.1.1/POSEIDON.yml
 1ab24c45ef3a13e0fb34afac7a21dca8 timetravel timetravel/Schmid_2028-1.0.0/POSEIDON.yml
 8d57ce1a1ab28c0d8a5f391dd790a59c fetch fetch/by_package/Lamnidis_2018-1.0.1/POSEIDON.yml
 1ab24c45ef3a13e0fb34afac7a21dca8 fetch fetch/by_package/Schmid_2028-1.0.0/POSEIDON.yml

--- a/test/PoseidonGoldenTests/GoldenTestData/chronicle/Schiffels/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/chronicle/Schiffels/POSEIDON.yml
@@ -5,8 +5,6 @@ contributor:
 - name: Josiah Carberry
   email: carberry@brown.edu
   orcid: 0000-0002-1825-0097
-- name: Berta Testfrau
-  email: berta@testfrau.org
 - name: Herbert Testmann
   email: herbert@testmann.tw
 packageVersion: 1.1.1

--- a/test/PoseidonGoldenTests/GoldenTestData/chronicle/Schiffels_2016/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/chronicle/Schiffels_2016/POSEIDON.yml
@@ -4,6 +4,9 @@ description: Genetic data published in Schiffels et al. 2016
 contributor:
 - name: Stephan Schiffels
   email: schiffels@institute.org
+- name: Josiah Carberry
+  email: carberry@brown.edu
+  orcid: 0000-0002-1825-0097
 packageVersion: 1.0.1
 lastModified: 2021-11-09
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/chronicle/chronicle2.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/chronicle/chronicle2.yml
@@ -1,29 +1,29 @@
 title: Chronicle title
 description: Chronicle description
 chronicleVersion: 0.2.0
-lastModified: 2024-02-22
+lastModified: 2024-04-02
 packages:
 - title: Lamnidis_2018
   version: 1.0.0
-  commit: 14f4b6a0b1670ebe4b2544eeb1d74efd4f618b28
+  commit: dbec249fe4197c78502ed0cecd2d7fff855e6463
   path: Lamnidis_2018
 - title: Lamnidis_2018
   version: 1.0.1
-  commit: 14f4b6a0b1670ebe4b2544eeb1d74efd4f618b28
+  commit: dbec249fe4197c78502ed0cecd2d7fff855e6463
   path: Lamnidis_2018_newVersion
 - title: Schiffels
   version: 1.1.1
-  commit: de7c7af1794902b9f85bc57975a0af960d5c24bc
+  commit: 585c055f40836db0fbde0267cd6e8c472f8f6ff3
   path: Schiffels
 - title: Schiffels_2016
   version: 1.0.1
-  commit: 14f4b6a0b1670ebe4b2544eeb1d74efd4f618b28
+  commit: dbec249fe4197c78502ed0cecd2d7fff855e6463
   path: Schiffels_2016
 - title: Schmid_2028
   version: 1.0.0
-  commit: 14f4b6a0b1670ebe4b2544eeb1d74efd4f618b28
+  commit: dbec249fe4197c78502ed0cecd2d7fff855e6463
   path: Schmid_2028
 - title: Wang_2020
   version: 0.1.0
-  commit: 14f4b6a0b1670ebe4b2544eeb1d74efd4f618b28
+  commit: dbec249fe4197c78502ed0cecd2d7fff855e6463
   path: Wang_2020

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac1/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac1/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac1
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac10/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac10/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac10
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac11/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac11/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac11
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac12/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac12/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac12
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac13/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac13/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac13
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac14/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac14/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac14
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac15/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac15/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac15
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac16/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac16/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac16
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac17/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac17/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac17
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac3/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac3/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac3
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac4/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac4/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac4
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac5/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac5/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac5
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac7/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac7/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac7
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac8/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac8/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac8
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac9/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/forge/ForgePac9/POSEIDON.yml
@@ -1,10 +1,6 @@
 poseidonVersion: 2.7.1
 title: ForgePac9
 description: Empty package template. Please add a description
-contributor:
-- name: Josiah Carberry
-  email: carberry@brown.edu
-  orcid: 0000-0002-1825-0097
 packageVersion: 0.1.0
 lastModified: 1970-01-01
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestData/init/Schiffels/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/init/Schiffels/POSEIDON.yml
@@ -5,8 +5,6 @@ contributor:
 - name: Josiah Carberry
   email: carberry@brown.edu
   orcid: 0000-0002-1825-0097
-- name: Berta Testfrau
-  email: berta@testfrau.org
 - name: Herbert Testmann
   email: herbert@testmann.tw
 packageVersion: 1.1.1

--- a/test/PoseidonGoldenTests/GoldenTestData/timetravel/Schiffels-1.1.1/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/timetravel/Schiffels-1.1.1/POSEIDON.yml
@@ -5,8 +5,6 @@ contributor:
 - name: Josiah Carberry
   email: carberry@brown.edu
   orcid: 0000-0002-1825-0097
-- name: Berta Testfrau
-  email: berta@testfrau.org
 - name: Herbert Testmann
   email: herbert@testmann.tw
 packageVersion: 1.1.1

--- a/test/PoseidonGoldenTests/GoldenTestData/timetravel/Schiffels_2016-1.0.1/POSEIDON.yml
+++ b/test/PoseidonGoldenTests/GoldenTestData/timetravel/Schiffels_2016-1.0.1/POSEIDON.yml
@@ -4,6 +4,9 @@ description: Genetic data published in Schiffels et al. 2016
 contributor:
 - name: Stephan Schiffels
   email: schiffels@institute.org
+- name: Josiah Carberry
+  email: carberry@brown.edu
+  orcid: 0000-0002-1825-0097
 packageVersion: 1.0.1
 lastModified: 2021-11-09
 genotypeData:

--- a/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
+++ b/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
@@ -63,6 +63,7 @@ import           System.FilePath.Posix      ((</>))
 import           System.IO                  (IOMode (WriteMode), hPutStrLn,
                                              openFile, stderr, stdout, withFile)
 import           System.Process             (callCommand)
+import Poseidon.Contributor (ORCID(..))
 
 -- file paths --
 
@@ -485,7 +486,7 @@ testPipelineRectify testDir checkFilePath = do
         , _rectifyPackageVersionUpdate = Just (PackageVersionUpdate Patch Nothing)
         , _rectifyChecksums = ChecksumNone
         , _rectifyNewContributors = Just [
-              ContributorSpec "Berta Testfrau" "berta@testfrau.org" Nothing
+              ContributorSpec "Josiah Carberry" "carberry@brown.edu" (Just $ ORCID {_orcidNums = "000000021825009", _orcidChecksum = '7'})
             , ContributorSpec "Herbert Testmann" "herbert@testmann.tw" Nothing
             ]
         , _rectifyOnlyLatest = False

--- a/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
+++ b/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
@@ -53,6 +53,7 @@ import           GHC.IO.Handle              (hClose, hDuplicate, hDuplicateTo)
 import           Poseidon.CLI.Chronicle     (ChronOperation (..),
                                              ChronicleOptions (..),
                                              runChronicle)
+import           Poseidon.Contributor       (ORCID (..))
 import           Poseidon.EntityTypes       (PacNameAndVersion (..))
 import           SequenceFormats.Plink      (PlinkPopNameMode (..))
 import           System.Directory           (copyFile, createDirectory,
@@ -63,7 +64,6 @@ import           System.FilePath.Posix      ((</>))
 import           System.IO                  (IOMode (WriteMode), hPutStrLn,
                                              openFile, stderr, stdout, withFile)
 import           System.Process             (callCommand)
-import Poseidon.Contributor (ORCID(..))
 
 -- file paths --
 

--- a/test/testDat/testPackages/ancient/Schiffels_2016/POSEIDON.yml
+++ b/test/testDat/testPackages/ancient/Schiffels_2016/POSEIDON.yml
@@ -4,6 +4,9 @@ description: Genetic data published in Schiffels et al. 2016
 contributor:
 - name: Stephan Schiffels
   email: schiffels@institute.org
+- name: Josiah Carberry
+  email: carberry@brown.edu
+  orcid: 0000-0002-1825-0097
 packageVersion: 1.0.1
 lastModified: 2021-11-09
 genotypeData:


### PR DESCRIPTION
This solves #289 if merged. I applied the following changes:

- removed Josiah from `newPackageTemplate`, so that he doesn't get added any more to new packages created by `init` and `forge` - the contributor field is missing in the output of these commands now
- adjusted the golden test output accordingly, but also added Josiah to one of the test packages (`test/testDat/testPackages/ancient/Schiffels_2016`) to keep him around at least in one way and make sure that the ORCID parser runs in the tests
- added a new warning to the package reading process to point out an empty contributor field:

```
[Warning] Contributor missing in POSEIDON.yml file of package 2010_RasmussenNature-2.1.1
```