### PR TITLE
removed a lot of unused (?) ToJSON and FromJSON instances

### DIFF
--- a/src/Poseidon/ColumnTypes.hs
+++ b/src/Poseidon/ColumnTypes.hs
@@ -8,9 +8,6 @@ import           Poseidon.ColumnTypesUtils
 
 import           Country                    (Country, alphaTwoUpper,
                                              decodeAlphaTwo)
-import           Data.Aeson                 (FromJSON, ToJSON, Value (..),
-                                             defaultOptions, genericToEncoding,
-                                             parseJSON, toEncoding, toJSON)
 import qualified Data.Csv                   as Csv
 import qualified Data.Text                  as T
 import qualified Data.Text.Read             as T
@@ -43,8 +40,6 @@ instance Ord GeneticSex where
     compare _ _                                      = EQ
 instance Csv.ToField GeneticSex where   toField x  = Csv.toField $ show x
 instance Csv.FromField GeneticSex where parseField = parseTypeCSV "Genetic_Sex"
-instance ToJSON GeneticSex where        toJSON x   = String $ T.pack $ show x
-instance FromJSON GeneticSex where      parseJSON  = parseTypeJSON "JannoSex"
 
 -- | A datatype for the Group_Name .janno column
 newtype GroupName = GroupName T.Text deriving (Eq, Ord)
@@ -92,8 +87,6 @@ instance Show JannoRelationDegree where
     show OtherDegree  = "other"
 instance Csv.ToField JannoRelationDegree where   toField x = Csv.toField $ show x
 instance Csv.FromField JannoRelationDegree where parseField = parseTypeCSV "Relation_Degree"
-instance ToJSON JannoRelationDegree where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoRelationDegree
 
 -- | A datatype for the Relation_Type .janno column
 newtype JannoRelationType = JannoRelationType T.Text deriving (Eq)
@@ -124,8 +117,6 @@ instance Makeable JannoCountryISO where
         Just c  -> return $ JannoCountryISO c
 instance Csv.ToField JannoCountryISO where   toField x = Csv.toField $ show x
 instance Csv.FromField JannoCountryISO where parseField = parseTypeCSV "Country_ISO"
-instance ToJSON JannoCountryISO where        toJSON x  = String $ T.pack $ show x
-instance FromJSON JannoCountryISO where      parseJSON = parseTypeJSON "Country_ISO"
 
 -- | A datatype for the Location .janno column
 newtype JannoLocation = JannoLocation T.Text deriving (Eq)
@@ -150,8 +141,6 @@ instance Makeable JannoLatitude where
 instance Show JannoLatitude where          show (JannoLatitude x) = show x
 instance Csv.ToField JannoLatitude where   toField (JannoLatitude x) = Csv.toField x
 instance Csv.FromField JannoLatitude where parseField = parseTypeCSV "Latitude"
-instance ToJSON JannoLatitude where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoLatitude
 
 -- | A datatype for the Longitude .janno column
 newtype JannoLongitude = JannoLongitude Double deriving (Eq, Ord, Generic)
@@ -168,8 +157,6 @@ instance Makeable JannoLongitude where
 instance Show JannoLongitude where          show (JannoLongitude x) = show x
 instance Csv.ToField JannoLongitude where   toField (JannoLongitude x) = Csv.toField x
 instance Csv.FromField JannoLongitude where parseField = parseTypeCSV "Longitude"
-instance ToJSON JannoLongitude where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoLongitude
 
 -- | A datatype for the Date_Type .janno column
 data JannoDateType =
@@ -191,8 +178,6 @@ instance Show JannoDateType where
     show Modern     = "modern"
 instance Csv.ToField JannoDateType where   toField x = Csv.toField $ show x
 instance Csv.FromField JannoDateType where parseField = parseTypeCSV "Date_Type"
-instance ToJSON JannoDateType where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoDateType
 
 -- | A datatype for the Date_C14_Labnr .janno column
 newtype JannoDateC14Labnr = JannoDateC14Labnr T.Text deriving (Eq)
@@ -210,8 +195,6 @@ instance Makeable JannoDateC14UncalBP where
 instance Show JannoDateC14UncalBP where          show (JannoDateC14UncalBP x) = show x
 instance Csv.ToField JannoDateC14UncalBP where   toField (JannoDateC14UncalBP x) = Csv.toField x
 instance Csv.FromField JannoDateC14UncalBP where parseField = parseTypeCSV "Date_C14_Uncal_BP"
-instance ToJSON JannoDateC14UncalBP where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoDateC14UncalBP
 
 -- | A datatype for the Date_C14_Uncal_BP_Err .janno column
 newtype JannoDateC14UncalBPErr = JannoDateC14UncalBPErr Int deriving (Eq, Ord, Generic)
@@ -225,8 +208,6 @@ instance Makeable JannoDateC14UncalBPErr where
 instance Show JannoDateC14UncalBPErr where          show (JannoDateC14UncalBPErr x) = show x
 instance Csv.ToField JannoDateC14UncalBPErr where   toField (JannoDateC14UncalBPErr x) = Csv.toField x
 instance Csv.FromField JannoDateC14UncalBPErr where parseField = parseTypeCSV "Date_C14_Uncal_BP_Err"
-instance ToJSON JannoDateC14UncalBPErr where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoDateC14UncalBPErr
 
 -- | A datatype for the Date_BC_AD_Start .janno column
 newtype JannoDateBCADStart = JannoDateBCADStart Int deriving (Eq, Ord, Generic)
@@ -245,8 +226,6 @@ instance Makeable JannoDateBCADStart where
 instance Show JannoDateBCADStart where          show (JannoDateBCADStart x) = show x
 instance Csv.ToField JannoDateBCADStart where   toField (JannoDateBCADStart x) = Csv.toField x
 instance Csv.FromField JannoDateBCADStart where parseField = parseTypeCSV "Date_BC_AD_Start"
-instance ToJSON JannoDateBCADStart where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoDateBCADStart
 
 -- | A datatype for the Date_BC_AD_Median .janno column
 newtype JannoDateBCADMedian = JannoDateBCADMedian Int deriving (Eq, Ord, Generic)
@@ -265,8 +244,6 @@ instance Makeable JannoDateBCADMedian where
 instance Show JannoDateBCADMedian where          show (JannoDateBCADMedian x) = show x
 instance Csv.ToField JannoDateBCADMedian where   toField (JannoDateBCADMedian x) = Csv.toField x
 instance Csv.FromField JannoDateBCADMedian where parseField = parseTypeCSV "Date_BC_AD_Median"
-instance ToJSON JannoDateBCADMedian where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoDateBCADMedian
 
 -- | A datatype for the Date_BC_AD_Stop .janno column
 newtype JannoDateBCADStop = JannoDateBCADStop Int deriving (Eq, Ord, Generic)
@@ -285,8 +262,6 @@ instance Makeable JannoDateBCADStop where
 instance Show JannoDateBCADStop where          show (JannoDateBCADStop x) = show x
 instance Csv.ToField JannoDateBCADStop where   toField (JannoDateBCADStop x) = Csv.toField x
 instance Csv.FromField JannoDateBCADStop where parseField = parseTypeCSV "Date_BC_AD_Stop"
-instance ToJSON JannoDateBCADStop where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoDateBCADStop
 
 -- | A datatype for the Date_Note .janno column
 newtype JannoDateNote = JannoDateNote T.Text deriving (Eq, Ord)
@@ -319,8 +294,6 @@ instance Makeable JannoNrLibraries where
 instance Show JannoNrLibraries where          show (JannoNrLibraries x) = show x
 instance Csv.ToField JannoNrLibraries where   toField (JannoNrLibraries x) = Csv.toField x
 instance Csv.FromField JannoNrLibraries where parseField = parseTypeCSV "Nr_Libraries"
-instance ToJSON JannoNrLibraries where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoNrLibraries
 
 -- | A datatype for the Library_Names .janno column
 newtype JannoLibraryName = JannoLibraryName T.Text deriving (Eq)
@@ -361,8 +334,6 @@ instance Show JannoCaptureType where
     show ReferenceGenome    = "ReferenceGenome"
 instance Csv.ToField JannoCaptureType where   toField x = Csv.toField $ show x
 instance Csv.FromField JannoCaptureType where parseField = parseTypeCSV "Capture_Type"
-instance ToJSON JannoCaptureType where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoCaptureType
 
 -- | A datatype for the UDG .janno column
 data JannoUDG =
@@ -387,8 +358,6 @@ instance Show JannoUDG where
     show Mixed = "mixed"
 instance Csv.ToField JannoUDG where   toField x = Csv.toField $ show x
 instance Csv.FromField JannoUDG where parseField = parseTypeCSV "UDG"
-instance ToJSON JannoUDG where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoUDG
 
 -- | A datatype for the Library_Built .janno column
 data JannoLibraryBuilt =
@@ -413,8 +382,6 @@ instance Show JannoLibraryBuilt where
     show Other     = "other"
 instance Csv.ToField JannoLibraryBuilt where   toField x = Csv.toField $ show x
 instance Csv.FromField JannoLibraryBuilt where parseField = parseTypeCSV "Library_Built"
-instance ToJSON JannoLibraryBuilt where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoLibraryBuilt
 
 -- | A datatype for the Genotype_Ploidy .janno column
 data JannoGenotypePloidy =
@@ -433,8 +400,6 @@ instance Show JannoGenotypePloidy where
     show Haploid = "haploid"
 instance Csv.ToField JannoGenotypePloidy where   toField x = Csv.toField $ show x
 instance Csv.FromField JannoGenotypePloidy where parseField = parseTypeCSV "Genotype_Ploidy"
-instance ToJSON JannoGenotypePloidy where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoGenotypePloidy
 
 -- | A datatype for the Genotype_Ploidy .janno column
 newtype JannoDataPreparationPipelineURL = JannoDataPreparationPipelineURL T.Text deriving (Eq, Ord, Generic)
@@ -446,8 +411,6 @@ instance Makeable JannoDataPreparationPipelineURL where
 instance Show JannoDataPreparationPipelineURL where          show (JannoDataPreparationPipelineURL x) = T.unpack x
 instance Csv.ToField JannoDataPreparationPipelineURL where   toField (JannoDataPreparationPipelineURL x) = Csv.toField x
 instance Csv.FromField JannoDataPreparationPipelineURL where parseField = parseTypeCSV "Data_Preparation_Pipeline_URL"
-instance ToJSON JannoDataPreparationPipelineURL where        toJSON (JannoDataPreparationPipelineURL x) = String x
-instance FromJSON JannoDataPreparationPipelineURL
 
 -- | A datatype for the Endogenous .janno column
 newtype JannoEndogenous = JannoEndogenous Double deriving (Eq, Ord, Generic)
@@ -464,8 +427,6 @@ instance Makeable JannoEndogenous where
 instance Show JannoEndogenous where          show (JannoEndogenous x) = show x
 instance Csv.ToField JannoEndogenous where   toField (JannoEndogenous x) = Csv.toField x
 instance Csv.FromField JannoEndogenous where parseField = parseTypeCSV "Endogenous"
-instance ToJSON JannoEndogenous where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoEndogenous
 
 -- | A datatype for the Nr_SNPs .janno column
 newtype JannoNrSNPs = JannoNrSNPs Int deriving (Eq, Ord, Generic)
@@ -482,8 +443,6 @@ instance Makeable JannoNrSNPs where
 instance Show JannoNrSNPs where          show (JannoNrSNPs x) = show x
 instance Csv.ToField JannoNrSNPs where   toField (JannoNrSNPs x) = Csv.toField x
 instance Csv.FromField JannoNrSNPs where parseField = parseTypeCSV "Nr_SNPs"
-instance ToJSON JannoNrSNPs where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoNrSNPs
 
 -- | A datatype for the Coverage_on_Target_SNPs .janno column
 newtype JannoCoverageOnTargets = JannoCoverageOnTargets Double deriving (Eq, Ord, Generic)
@@ -497,8 +456,6 @@ instance Makeable JannoCoverageOnTargets where
 instance Show JannoCoverageOnTargets where          show (JannoCoverageOnTargets x) = show x
 instance Csv.ToField JannoCoverageOnTargets where   toField (JannoCoverageOnTargets x) = Csv.toField x
 instance Csv.FromField JannoCoverageOnTargets where parseField = parseTypeCSV "Coverage_on_Target_SNPs"
-instance ToJSON JannoCoverageOnTargets where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoCoverageOnTargets
 
 -- | A datatype for the Damage .janno column
 newtype JannoDamage = JannoDamage Double deriving (Eq, Ord, Generic)
@@ -515,8 +472,6 @@ instance Makeable JannoDamage where
 instance Show JannoDamage where          show (JannoDamage x) = show x
 instance Csv.ToField JannoDamage where   toField (JannoDamage x) = Csv.toField x
 instance Csv.FromField JannoDamage where parseField = parseTypeCSV "Damage"
-instance ToJSON JannoDamage where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoDamage
 
 -- | A datatype for the Contamination .janno column
 newtype JannoContamination = JannoContamination T.Text deriving (Eq)
@@ -567,8 +522,6 @@ instance Show JannoGeneticSourceAccessionID where
     show (OtherID x)         = T.unpack x
 instance Csv.ToField JannoGeneticSourceAccessionID where   toField x  = Csv.toField $ show x
 instance Csv.FromField JannoGeneticSourceAccessionID where parseField = parseTypeCSV "Genetic_Source_Accession_IDs"
-instance ToJSON JannoGeneticSourceAccessionID where        toEncoding = genericToEncoding defaultOptions
-instance FromJSON JannoGeneticSourceAccessionID
 
 -- | A datatype for the Primary_Contact .janno column
 newtype JannoPrimaryContact = JannoPrimaryContact T.Text deriving (Eq)

--- a/src/Poseidon/ColumnTypesUtils.hs
+++ b/src/Poseidon/ColumnTypesUtils.hs
@@ -3,9 +3,6 @@
 
 module Poseidon.ColumnTypesUtils where
 
-import           Data.Aeson          (FromJSON, ToJSON, Value (..), parseJSON,
-                                      toJSON, withText)
-import           Data.Aeson.Types    (Parser)
 import           Data.ByteString     as S
 import qualified Data.Csv            as Csv
 import qualified Data.Text           as T
@@ -25,9 +22,6 @@ parseTypeCSV colname x = case T.decodeUtf8' x of
         Left e  -> fail $ show e ++ " in column " ++ colname
         Right t -> make t
 
-parseTypeJSON :: forall a. (Makeable a, Typeable a) => String -> Value -> Parser a
-parseTypeJSON colname = withText colname make
-
 -- template haskell function to generate repetitive instances
 makeInstances :: Name -> String -> DecsQ
 makeInstances name col = do
@@ -38,6 +32,4 @@ makeInstances name col = do
       instance Show $(conT name) where          show $(conP conName [varP x]) = T.unpack $(varE x)
       instance Csv.ToField $(conT name) where   toField $(conP conName [varP x]) = Csv.toField $(varE x)
       instance Csv.FromField $(conT name) where parseField = parseTypeCSV col
-      instance ToJSON $(conT name) where        toJSON $(conP conName [varP x]) = String $(varE x)
-      instance FromJSON $(conT name) where      parseJSON = parseTypeJSON col
       |]

--- a/src/Poseidon/SequencingSource.hs
+++ b/src/Poseidon/SequencingSource.hs
@@ -19,10 +19,6 @@ import           Poseidon.Utils             (PoseidonException (..), PoseidonIO,
 import           Control.Exception          (throwIO)
 import           Control.Monad              (unless, when)
 import           Control.Monad.IO.Class     (liftIO)
-import           Data.Aeson                 (FromJSON, Options (..), ToJSON,
-                                             defaultOptions, genericToEncoding,
-                                             toEncoding, withText)
-import           Data.Aeson.Encoding        (text)
 import           Data.Bifunctor             (second)
 import qualified Data.ByteString.Char8      as Bchs
 import qualified Data.ByteString.Lazy.Char8 as Bch
@@ -32,12 +28,10 @@ import           Data.Either                (lefts, rights)
 import qualified Data.HashMap.Strict        as HM
 import           Data.List                  (foldl', nub, sort)
 import           Data.Maybe                 (isJust, mapMaybe)
-import qualified Data.Text                  as T
 import           Data.Time                  (Day)
 import           Data.Time.Format           (defaultTimeLocale, formatTime,
                                              parseTimeM)
 import qualified Data.Vector                as V
-import           Data.Yaml.Aeson            (FromJSON (..))
 import           GHC.Generics               (Generic)
 import           Network.URI                (isURIReference)
 import qualified Text.Parsec                as P
@@ -82,11 +76,6 @@ instance Csv.ToField AccessionID where
     toField x = Csv.toField $ show x
 instance Csv.FromField AccessionID where
     parseField x = Csv.parseField x >>= makeAccessionID
-instance ToJSON AccessionID where
-    toEncoding = genericToEncoding defaultOptions
-    --toEncoding x = text $ T.pack $ show x
-instance FromJSON AccessionID-- where
-    --parseJSON = withText "AccessionID" (makeAccessionID . T.unpack)
 
 -- | A datatype to represent URIs in a ssf file
 newtype JURI =
@@ -105,11 +94,6 @@ instance Csv.ToField JURI where
     toField x = Csv.toField $ show x
 instance Csv.FromField JURI where
     parseField x = Csv.parseField x >>= makeJURI
-instance ToJSON JURI where
-    toEncoding = genericToEncoding defaultOptions
-    --toEncoding x = text $ T.pack $ show x
-instance FromJSON JURI-- where
-    --parseJSON = withText "JURI" (makeJURI . T.unpack)
 
 -- |A datatype to represent UDG in a ssf file
 data SSFUDG =
@@ -134,10 +118,6 @@ instance Csv.ToField SSFUDG where
     toField x = Csv.toField $ show x
 instance Csv.FromField SSFUDG where
     parseField x = Csv.parseField x >>= makeSSFUDG
-instance ToJSON SSFUDG where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON SSFUDG where
-    parseJSON = withText "SSFUDG" (makeSSFUDG . T.unpack)
 
 -- |A datatype to represent Library_Built in a janno file
 data SSFLibraryBuilt =
@@ -159,10 +139,6 @@ instance Csv.ToField SSFLibraryBuilt where
     toField x = Csv.toField $ show x
 instance Csv.FromField SSFLibraryBuilt where
     parseField x = Csv.parseField x >>= makeSSFLibraryBuilt
-instance ToJSON SSFLibraryBuilt where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON SSFLibraryBuilt where
-    parseJSON = withText "SSFLibraryBuilt" (makeSSFLibraryBuilt . T.unpack)
 
 -- | A data type to represent a seqSourceFile
 newtype SeqSourceRows = SeqSourceRows {getSeqSourceRowList :: [SeqSourceRow]}
@@ -187,10 +163,6 @@ instance Monoid SeqSourceRows where
     mempty = SeqSourceRows []
     mconcat = foldl' mappend mempty
 
-instance ToJSON SeqSourceRows where
-    toEncoding = genericToEncoding defaultOptions
-instance FromJSON SeqSourceRows
-
 -- A data type to represent a run accession ID
 newtype AccessionIDRun = AccessionIDRun {getRunAccession :: AccessionID}
     deriving (Eq, Generic)
@@ -209,10 +181,6 @@ instance Csv.ToField AccessionIDRun where
     toField x = Csv.toField $ show x
 instance Csv.FromField AccessionIDRun where
     parseField x = Csv.parseField x >>= makeAccessionIDRun
-instance ToJSON AccessionIDRun where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON AccessionIDRun where
-    parseJSON = withText "AccessionIDRun" (makeAccessionIDRun . T.unpack)
 
 -- A data type to represent a sample accession ID
 newtype AccessionIDSample = AccessionIDSample {getSampleAccession :: AccessionID}
@@ -233,10 +201,6 @@ instance Csv.ToField AccessionIDSample where
     toField x = Csv.toField $ show x
 instance Csv.FromField AccessionIDSample where
     parseField x = Csv.parseField x >>= makeAccessionIDSample
-instance ToJSON AccessionIDSample where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON AccessionIDSample where
-    parseJSON = withText "AccessionIDSample" (makeAccessionIDSample . T.unpack)
 
 -- A data type to represent a study accession ID
 newtype AccessionIDStudy = AccessionIDStudy {getStudyAccession :: AccessionID}
@@ -257,10 +221,6 @@ instance Csv.ToField AccessionIDStudy where
     toField x = Csv.toField $ show x
 instance Csv.FromField AccessionIDStudy where
     parseField x = Csv.parseField x >>= makeAccessionIDStudy
-instance ToJSON AccessionIDStudy where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON AccessionIDStudy where
-    parseJSON = withText "AccessionIDStudy" (makeAccessionIDStudy . T.unpack)
 
 -- | A datatype for calendar dates
 newtype SimpleDate = SimpleDate Day
@@ -278,10 +238,6 @@ instance Csv.ToField SimpleDate where
     toField (SimpleDate x) = Csv.toField $ show x
 instance Csv.FromField SimpleDate where
     parseField x = Csv.parseField x >>= makeSimpleDate
-instance ToJSON SimpleDate where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON SimpleDate where
-    parseJSON = withText "SimpleDate" (makeSimpleDate . T.unpack)
 
 -- | A datatype to represent MD5 hashes
 newtype MD5 = MD5 String
@@ -302,10 +258,6 @@ instance Csv.ToField MD5 where
     toField x = Csv.toField $ show x
 instance Csv.FromField MD5 where
     parseField x = Csv.parseField x >>= makeMD5
-instance ToJSON MD5 where
-    toEncoding x = text $ T.pack $ show x
-instance FromJSON MD5 where
-    parseJSON = withText "MD5" (makeMD5 . T.unpack)
 
 -- | A data type to represent a row in the seqSourceFile
 -- See https://github.com/poseidon-framework/poseidon2-schema/blob/master/seqSourceFile_columns.tsv
@@ -373,11 +325,6 @@ seqSourceHeaderString = map Bchs.unpack seqSourceHeader
 -- This hashmap represents an empty seqSourceFile with all normal, specified columns
 seqSourceRefHashMap :: HM.HashMap Bchs.ByteString ()
 seqSourceRefHashMap = HM.fromList $ map (\x -> (x, ())) seqSourceHeader
-
-instance ToJSON SeqSourceRow where
-    toEncoding = genericToEncoding (defaultOptions {omitNothingFields = True})
-
-instance FromJSON SeqSourceRow
 
 instance Csv.FromNamedRecord SeqSourceRow where
     parseNamedRecord m = SeqSourceRow

--- a/src/Poseidon/ServerClient.hs
+++ b/src/Poseidon/ServerClient.hs
@@ -17,7 +17,6 @@ import           Poseidon.EntityTypes   (HasNameAndVersion (..),
                                          IndividualInfo (..),
                                          IndividualInfoCollection,
                                          PacNameAndVersion (..))
-import           Poseidon.Janno         (JannoRows)
 import           Poseidon.Utils         (PoseidonException (..), PoseidonIO,
                                          logError, logInfo)
 
@@ -29,7 +28,6 @@ import           Data.Aeson             (FromJSON, ToJSON (..), Value (String),
                                          toJSON, withObject, (.:), (.=))
 import           Data.Time              (Day)
 import           Data.Version           (Version, showVersion)
-import           GHC.Generics           (Generic)
 import           Network.HTTP.Conduit   (simpleHttp)
 
 --  Client Server Communication types and functions
@@ -77,7 +75,6 @@ instance FromJSON ServerApiReturnType where
 data ApiReturnData = ApiReturnPackageInfo [PackageInfo]
                    | ApiReturnGroupInfo [GroupInfo]
                    | ApiReturnExtIndividualInfo [ExtendedIndividualInfo]
-                   | ApiReturnJanno [(String, JannoRows)] deriving (Generic)
 
 instance ToJSON ApiReturnData where
     toJSON (ApiReturnPackageInfo pacInfo) =
@@ -95,11 +92,6 @@ instance ToJSON ApiReturnData where
             "constructor" .= String "ApiReturnExtIndividualInfo",
             "extIndInfo" .= indInfo
         ]
-    toJSON (ApiReturnJanno janno) =
-        object [
-            "constructor" .= String "ApiReturnJanno",
-            "janno" .= janno
-        ]
 
 instance FromJSON ApiReturnData where
     parseJSON = withObject "ApiReturnData" $ \v -> do
@@ -108,7 +100,6 @@ instance FromJSON ApiReturnData where
             "ApiReturnPackageInfo"       -> ApiReturnPackageInfo       <$> v .: "packageInfo"
             "ApiReturnGroupInfo"         -> ApiReturnGroupInfo         <$> v .: "groupInfo"
             "ApiReturnExtIndividualInfo" -> ApiReturnExtIndividualInfo <$> v .: "extIndInfo"
-            "ApiReturnJanno"             -> ApiReturnJanno             <$> v .: "janno"
             _                            -> error $ "cannot parse ApiReturnType with constructor " ++ constr
 
 

--- a/test/Poseidon/JannoSpec.hs
+++ b/test/Poseidon/JannoSpec.hs
@@ -9,13 +9,11 @@ import           Poseidon.Janno            (CsvNamedRecord (..), JannoRow (..),
 import           Poseidon.SequencingSource (JURI (..))
 import           Poseidon.Utils            (testLog)
 
-import           Control.Applicative       (liftA2)
 import           Country                   (decodeAlphaTwo)
-import qualified Data.Aeson                as A
 import qualified Data.Csv                  as C
 import           Data.HashMap.Strict       (fromList)
 import           System.FilePath           ((</>))
-import           Test.Hspec                (Expectation, Spec, anyException,
+import           Test.Hspec                (Spec, anyException,
                                             describe, it, shouldBe, shouldThrow)
 
 spec :: Spec
@@ -51,16 +49,8 @@ testEnAndDecoding = describe "Poseidon.Janno: JSON and CSV en- and decoding" $ d
         checkEnDe ([Nothing, Just $ JannoLatitude (-45), Just $ JannoLatitude 45] :: [Maybe JannoLatitude])
 
 -- infrastructure to check an en- and decoding cycle
-checkEnDe :: (Show a, Eq a, A.FromJSON a, A.ToJSON a, C.FromField a, C.ToField a) => [a] -> IO ()
-checkEnDe = liftA2 (>>) checkAeson checkCassava
-checkAeson :: (Show a, Eq a, A.FromJSON a, A.ToJSON a) => [a] -> Expectation
-checkAeson xs = aesonCycle xs `shouldBe` aesonResult xs
-    where
-        aesonCycle :: (A.FromJSON a, A.ToJSON a) => [a] -> [Maybe a]
-        aesonCycle = map (A.decode . A.encode)
-        aesonResult = map Just
-checkCassava :: (Show a, Eq a, C.FromField a, C.ToField a) => [a] -> Expectation
-checkCassava xs = cassavaCycle xs `shouldBe` cassavaResult xs
+checkEnDe :: (Show a, Eq a, C.FromField a, C.ToField a) => [a] -> IO ()
+checkEnDe xs = cassavaCycle xs `shouldBe` cassavaResult xs
     where
         cassavaCycle :: (C.FromField a, C.ToField a) => [a] -> [Either String a]
         cassavaCycle = map (C.runParser . C.parseField . C.toField)

--- a/test/Poseidon/JannoSpec.hs
+++ b/test/Poseidon/JannoSpec.hs
@@ -13,8 +13,8 @@ import           Country                   (decodeAlphaTwo)
 import qualified Data.Csv                  as C
 import           Data.HashMap.Strict       (fromList)
 import           System.FilePath           ((</>))
-import           Test.Hspec                (Spec, anyException,
-                                            describe, it, shouldBe, shouldThrow)
+import           Test.Hspec                (Spec, anyException, describe, it,
+                                            shouldBe, shouldThrow)
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
Following the discussion in #307 here's a PR that removes a large number of ToJSON and FromJSON instances. Maybe you could finish the job in `ServerClient.hs`, @stschiff.

If we don't use the instances then I'm all for removing them :slightly_smiling_face:! 