### PR TITLE
Fix `parseInGenoSep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- V 1.5.7.4:
+    - Fixed a bug that broke the long-form genotype data input option (with `--genoFile + --snpFile + ...`).
 - V 1.5.7.3:
     - Allowed `0` in the `Nr_SNPs` .janno column.
 - V 1.5.7.2: 

--- a/poseidon-hs.cabal
+++ b/poseidon-hs.cabal
@@ -1,5 +1,5 @@
 name:                poseidon-hs
-version:             1.5.7.3
+version:             1.5.7.4
 synopsis:            A package with tools for working with Poseidon genotype data
 description:         The tools in this package read and analyse Poseidon-formatted genotype databases, a modular system for storing genotype data from thousands of individuals.
 license:             MIT

--- a/src/Poseidon/CLI/OptparseApplicativeParsers.hs
+++ b/src/Poseidon/CLI/OptparseApplicativeParsers.hs
@@ -37,9 +37,9 @@ import           Data.List.Split            (splitOn)
 import           Data.Version               (Version)
 import qualified Options.Applicative        as OP
 import           SequenceFormats.Plink      (PlinkPopNameMode (PlinkPopNameAsBoth, PlinkPopNameAsFamily, PlinkPopNameAsPhenotype))
-import           System.FilePath            (dropExtensions, splitExtension,
+import           System.FilePath            (splitExtension,
                                              splitExtensions, takeExtension,
-                                             takeExtensions, (<.>))
+                                             (<.>))
 import qualified Text.Parsec                as P
 import           Text.Read                  (readMaybe)
 
@@ -506,7 +506,7 @@ parseInGenoSep = parseEigenstrat <|> parsePlink <|> parseVCF
         pure Nothing <*>
         parseFileWithEndings "Eigenstrat individual file" "indFile" [".ind"] <*>
         pure Nothing
-    parsePlink = GenotypeEigenstrat <$>
+    parsePlink = GenotypePlink <$>
         parseFileWithEndings "Plink genotype matrix, optionally gzipped" "bedFile" [".bed", ".bed.gz"] <*>
         pure Nothing <*>
         parseFileWithEndings "Plink snp positions file, optionally gzipped" "bimFile" [".bim",  ".bim.gz"] <*>
@@ -523,7 +523,9 @@ parseFileWithEndings help long endings = OP.option (OP.maybeReader fileEndingRea
     OP.metavar "FILE")
   where
     fileEndingReader :: String -> Maybe FilePath
-    fileEndingReader optString = if takeExtensions optString `elem` endings then Just (dropExtensions optString) else Nothing
+    fileEndingReader p =
+        let (_, extension) = splitExtensionsOptGz p
+        in if extension `elem` endings then Just p else Nothing
 
 parseGenotypeSNPSet :: OP.Parser SNPSetSpec
 parseGenotypeSNPSet = OP.option (OP.eitherReader readSnpSet) (

--- a/src/Poseidon/CLI/OptparseApplicativeParsers.hs
+++ b/src/Poseidon/CLI/OptparseApplicativeParsers.hs
@@ -37,9 +37,8 @@ import           Data.List.Split            (splitOn)
 import           Data.Version               (Version)
 import qualified Options.Applicative        as OP
 import           SequenceFormats.Plink      (PlinkPopNameMode (PlinkPopNameAsBoth, PlinkPopNameAsFamily, PlinkPopNameAsPhenotype))
-import           System.FilePath            (splitExtension,
-                                             splitExtensions, takeExtension,
-                                             (<.>))
+import           System.FilePath            (splitExtension, splitExtensions,
+                                             takeExtension, (<.>))
 import qualified Text.Parsec                as P
 import           Text.Read                  (readMaybe)
 

--- a/test/Poseidon/InterfaceSpec.hs
+++ b/test/Poseidon/InterfaceSpec.hs
@@ -9,6 +9,7 @@ import           Test.Hspec
 spec :: Spec
 spec = do
     testParseInGenoOne
+    testParseInGenoSep
     testSplitExtensionsOptGz
 
 runParser :: OP.Parser a -> [String] -> Maybe a
@@ -28,6 +29,19 @@ testParseInGenoOne = describe
                 Just (GenotypePlink "path/to/file.bed.gz" Nothing
                                     "path/to/file.bim.gz" Nothing
                                     "path/to/file.fam"    Nothing)
+
+testParseInGenoSep :: Spec
+testParseInGenoSep = describe
+    "Poseidon.OptparseApplicativeParsers.parseInGenoSep" $ do
+        it "should return the expected paths for EIGENSTRAT data" $ do
+            runParser parseInGenoSep [
+                  "--genoFile", "path/to/file.test.geno.gz"
+                , "--snpFile",  "path/to/file.snp"
+                , "--indFile",  "path/to/file.ind"
+                ] `shouldBe`
+                Just (GenotypeEigenstrat "path/to/file.test.geno.gz" Nothing
+                                         "path/to/file.snp"          Nothing
+                                         "path/to/file.ind"          Nothing)
 
 testSplitExtensionsOptGz :: Spec
 testSplitExtensionsOptGz = describe

--- a/test/Poseidon/InterfaceSpec.hs
+++ b/test/Poseidon/InterfaceSpec.hs
@@ -42,6 +42,20 @@ testParseInGenoSep = describe
                 Just (GenotypeEigenstrat "path/to/file.test.geno.gz" Nothing
                                          "path/to/file.snp"          Nothing
                                          "path/to/file.ind"          Nothing)
+        it "should return the expected paths for PLINK data" $ do
+            runParser parseInGenoSep [
+                  "--bedFile", "path/to/file.test.bed.gz"
+                , "--bimFile", "path/to/file.bim"
+                , "--famFile", "path/to/file.fam"
+                ] `shouldBe`
+                Just (GenotypePlink "path/to/file.test.bed.gz" Nothing
+                                    "path/to/file.bim"         Nothing
+                                    "path/to/file.fam"         Nothing)
+        it "should return the expected paths for VCF data" $ do
+            runParser parseInGenoSep [
+                  "--vcfFile", "path/to/file.vcf"
+                ] `shouldBe`
+                Just (GenotypeVCF "path/to/file.vcf" Nothing)
 
 testSplitExtensionsOptGz :: Spec
 testSplitExtensionsOptGz = describe


### PR DESCRIPTION
Ui - `parseInGenoSep` has two bugs (I think): It removes needed file extensions (#321) and it reads PLINK data as `GenotypeEigenstrat`.

This is not a testament to good quality control... I really think we made a mistake with the way we set up our golden tests without the actual optparse-applicative interface.

Please check thoroughly to make sure we get it right now!