### PR TITLE
Adjusted server archive config system on top of #327

### DIFF
--- a/src-executables/Main-trident.hs
+++ b/src-executables/Main-trident.hs
@@ -261,7 +261,7 @@ timetravelOptParser = TimetravelOptions <$> parseBasePaths
                                         <*> parseTimetravelChronPath
 
 serveOptParser :: OP.Parser ServeOptions
-serveOptParser = ServeOptions <$> parseArchiveBasePaths
+serveOptParser = ServeOptions <$> parseArchiveConfig
                               <*> parseMaybeZipDir
                               <*> parsePort
                               <*> parseIgnoreChecksums

--- a/src/Poseidon/CLI/OptparseApplicativeParsers.hs
+++ b/src/Poseidon/CLI/OptparseApplicativeParsers.hs
@@ -10,6 +10,8 @@ import           Poseidon.CLI.List          (ListEntity (..),
                                              RepoLocationSpec (..))
 import           Poseidon.CLI.Rectify       (ChecksumsToRectify (..),
                                              PackageVersionUpdate (..))
+import           Poseidon.CLI.Serve         (ArchiveConfig (..),
+                                             ArchiveSpec (..))
 import           Poseidon.CLI.Validate      (ValidatePlan (..))
 import           Poseidon.Contributor       (ContributorSpec (..),
                                              contributorSpecParser)
@@ -21,7 +23,6 @@ import           Poseidon.GenotypeData      (GenoDataSource (..),
                                              GenotypeDataSpec (..),
                                              GenotypeFileSpec (..),
                                              SNPSetSpec (..))
-import Poseidon.CLI.Serve (ArchiveConfig (..), ArchiveSpec (..))
 import           Poseidon.ServerClient      (AddColSpec (..),
                                              ArchiveEndpoint (..))
 import           Poseidon.Utils             (ErrorLength (..), LogMode (..),
@@ -828,7 +829,7 @@ parseArchiveConfigCLI = ArchiveConfig <$> OP.some parseArchiveSpec
         in  case parts of
                 [name, fp] -> do
                     let fps = splitOn "," fp
-                    return $ ArchiveSpec name fps Nothing Nothing
+                    return $ ArchiveSpec name fps Nothing Nothing Nothing False
                 _ -> Left $ "could not parse archive and base directory " ++ str ++
                             ". Please use format name=path1,path2,... "
 

--- a/src/Poseidon/CLI/Serve.hs
+++ b/src/Poseidon/CLI/Serve.hs
@@ -460,5 +460,5 @@ getItemFromArchiveStore :: ArchiveStore a -> ActionM a
 getItemFromArchiveStore store = do
     maybeArchiveName <- queryParamMaybe "archive"
     case maybeArchiveName of
-        Nothing -> return . snd . head $ store
+        Nothing   -> return . snd . head $ store
         Just name -> getArchiveByName name store

--- a/src/Poseidon/CLI/Serve.hs
+++ b/src/Poseidon/CLI/Serve.hs
@@ -32,10 +32,9 @@ import           Codec.Archive.Zip            (Archive, addEntryToArchive,
                                                toEntry)
 import           Control.Concurrent.MVar      (MVar, newEmptyMVar, putMVar)
 import           Control.Monad                (foldM, forM, when)
-import           Control.Monad.IO.Class       (liftIO, MonadIO)
+import           Control.Monad.IO.Class       (MonadIO, liftIO)
 import qualified Data.ByteString.Lazy         as B
-import           Data.List                    (groupBy, intercalate,
-                                               sortOn)
+import           Data.List                    (groupBy, intercalate, sortOn)
 import           Data.List.Split              (splitOn)
 import           Data.Maybe                   (isJust, mapMaybe)
 import           Data.Ord                     (Down (..))
@@ -43,6 +42,9 @@ import           Data.Text.Lazy               (pack)
 import           Data.Time.Clock.POSIX        (utcTimeToPOSIXSeconds)
 import           Data.Version                 (Version, parseVersion,
                                                showVersion)
+import           Data.Yaml                    (FromJSON, decodeFileThrow,
+                                               parseJSON, (.:?))
+import           Data.Yaml.Aeson              (withObject, (.:))
 import           Network.Wai                  (pathInfo, queryString)
 import           Network.Wai.Handler.Warp     (defaultSettings, runSettings,
                                                setBeforeMainLoop, setPort)
@@ -63,8 +65,6 @@ import           Web.Scotty                   (ActionM, ScottyM, captureParam,
                                                notFound, queryParamMaybe, raw,
                                                redirect, request, scottyApp,
                                                setHeader, text)
-import Data.Yaml (FromJSON, parseJSON, (.:?), decodeFileThrow)
-import Data.Yaml.Aeson (withObject, (.:))
 
 data ServeOptions = ServeOptions
     { cliArchiveConfig   :: Either ArchiveConfig FilePath
@@ -79,16 +79,18 @@ newtype ArchiveConfig = ArchiveConfig [ArchiveSpec] deriving Show
 
 instance FromJSON ArchiveConfig where
     parseJSON = withObject "PoseidonYamlStruct" $ \v -> ArchiveConfig
-        <$> v .: "contributor"
+        <$> v .: "archives"
 
 parseArchiveConfigFile :: (MonadIO m) => FilePath -> m ArchiveConfig
 parseArchiveConfigFile = decodeFileThrow
 
 data ArchiveSpec = ArchiveSpec
-    { _archSpecName :: ArchiveName
-    , _archSpecPaths :: [FilePath]
+    { _archSpecName        :: ArchiveName
+    , _archSpecPaths       :: [FilePath]
     , _archSpecDescription :: Maybe String
-    , _archSpecURL :: Maybe String
+    , _archSpecURL         :: Maybe String
+    , _archSpecDataURL     :: Maybe String
+    , _archSpecZip         :: Bool
     } deriving (Show)
 
 instance FromJSON ArchiveSpec where
@@ -97,6 +99,8 @@ instance FromJSON ArchiveSpec where
         <*> v .:  "paths"
         <*> v .:? "description"
         <*> v .:? "URL"
+        <*> v .:? "dataURL"
+        <*> v .: "zip"
 
 type ZipStore = [(PacNameAndVersion, FilePath)] -- maps PackageName+Version to a zipfile-path
 
@@ -108,8 +112,15 @@ type ArchiveStore a = [(ArchiveSpec, a)] -- a generic lookup table from an archi
 getArchiveSpecs :: ArchiveStore a -> [ArchiveSpec]
 getArchiveSpecs = map fst
 
-getArchiveByName :: (MonadFail m) => ArchiveName -> ArchiveStore a -> m a
-getArchiveByName name store =
+getArchiveSpecByName :: (MonadFail m) => ArchiveName -> ArchiveStore a -> m ArchiveSpec
+getArchiveSpecByName name store =
+    case filter (\(spec, _) -> _archSpecName spec == name) store of
+      []         -> fail $ "Archive " <> name <> " does not exist"
+      [(spec,_)] -> pure spec
+      _          -> fail $ "Archive " <> name <> " is ambiguous"
+
+getArchiveContentByName :: (MonadFail m) => ArchiveName -> ArchiveStore a -> m a
+getArchiveContentByName name store =
     case filter (\(spec, _) -> _archSpecName spec == name) store of
       []      -> fail $ "Archive " <> name <> " does not exist"
       [(_,a)] -> pure a
@@ -227,23 +238,26 @@ runServer (ServeOptions archBaseDirs maybeZipPath port ignoreChecksums certFiles
             raw stylesBS
         -- landing page
         get "/" $ do
-            redirect ("/explorer")
+            redirect "/explorer"
         get "/explorer" $ do
             logRequest logA
             pacsPerArchive <- forM archiveSpecs $ \spec -> do
                 let n = _archSpecName spec
                     d = _archSpecDescription spec
                     u = _archSpecURL spec
-                pacs <- selectLatest <$> getArchiveByName n archiveStore
+                pacs <- selectLatest <$> getArchiveContentByName n archiveStore
                 return (n, d, u, pacs)
             mainPage pacsPerArchive
         -- archive pages
         get "/explorer/:archive_name" $ do
             logRequest logA
             archiveName <- captureParam "archive_name"
-            latestPacs  <- selectLatest <$> getArchiveByName archiveName archiveStore
+            spec <- getArchiveSpecByName archiveName archiveStore
+            let maybeArchiveDataURL = _archSpecDataURL spec
+                archiveZip = _archSpecZip spec
+            latestPacs  <- selectLatest <$> getArchiveContentByName archiveName archiveStore
             let mapMarkers = concatMap (prepMappable archiveName) latestPacs
-            archivePage archiveName mapMarkers latestPacs
+            archivePage archiveName maybeArchiveDataURL archiveZip mapMarkers latestPacs
         -- per package pages
         get "/explorer/:archive_name/:package_name" $ do
             archive_name <- captureParam "archive_name"
@@ -257,7 +271,7 @@ runServer (ServeOptions archBaseDirs maybeZipPath port ignoreChecksums certFiles
             pacVersionWL <- case parsePackageVersionString pacVersionString of
                 Nothing -> fail $ "Could not parse package version string " ++ pacVersionString
                 Just v -> return v
-            allPacs     <- getArchiveByName archiveName archiveStore
+            allPacs     <- getArchiveContentByName archiveName archiveStore
             allVersions <- prepPacVersions pacName allPacs
             oneVersion  <- prepPacVersion pacVersionWL allVersions
             let mapMarkers = prepMappable archiveName oneVersion
@@ -269,7 +283,7 @@ runServer (ServeOptions archBaseDirs maybeZipPath port ignoreChecksums certFiles
         get "/explorer/:archive_name/:package_name/:package_version/:sample" $ do
             logRequest logA
             archiveName <- captureParam "archive_name"
-            allPacs <- getArchiveByName archiveName archiveStore
+            allPacs <- getArchiveContentByName archiveName archiveStore
             pacName <- captureParam "package_name"
             allVersions <- prepPacVersions pacName allPacs
             pacVersionString <- captureParam "package_version"
@@ -330,9 +344,9 @@ prepPacVersion pacVersion pacs = do
     case pacVersion of
         Latest -> return $ head $ selectLatest pacs
         NumericalVersion v -> case filter (\pac -> getPacVersion pac == Just v) pacs of
-            [] -> fail $ "Package version " <> (show pacVersion) <> " does not exist"
+            [] -> fail $ "Package version " <> show pacVersion <> " does not exist"
             [x] -> return x
-            _ -> fail $ "Package version " <> (show pacVersion) <> " exists multiple times"
+            _ -> fail $ "Package version " <> show pacVersion <> " exists multiple times"
 
 prepSamples :: PoseidonPackage -> ActionM [JannoRow]
 prepSamples pac = return $ getJannoRowsFromPac pac
@@ -492,4 +506,4 @@ getItemFromArchiveStore store = do
     maybeArchiveName <- queryParamMaybe "archive"
     case maybeArchiveName of
         Nothing   -> return . snd . head $ store
-        Just name -> getArchiveByName name store
+        Just name -> getArchiveContentByName name store

--- a/src/Poseidon/ServerHTML.hs
+++ b/src/Poseidon/ServerHTML.hs
@@ -183,50 +183,29 @@ footer = H.footer ! A.style "border-top: 1px solid; padding: 1em; border-color: 
 
 -- html pages
 
-mainPage :: [(String,[PoseidonPackage])] -> S.ActionM ()
+mainPage :: [(String, Maybe String, Maybe String,[PoseidonPackage])] -> S.ActionM ()
 mainPage pacsPerArchive = do
   urlPath <- pathInfo <$> S.request
   S.html $ renderMarkup $ explorerPage urlPath $ do
     H.h1 "Archives"
-    H.ul $ forM_ pacsPerArchive $ \(archiveName, pacs) -> do
+    H.ul $ forM_ pacsPerArchive $ \(archiveName, maybeDescription, maybeURL, pacs) -> do
       let nrPackages = length pacs
       H.article $ do
         H.header $ do
           H.a ! A.href ("/explorer/" <> H.toValue archiveName) $
             H.toMarkup archiveName
+        -- normal archive
         H.toMarkup $ show nrPackages <> " packages"
-        -- cover special cases for the main archive explorer website
-        case archiveName of
-          "community-archive" -> do
+        -- archives with more infoFullDesc
+        case (maybeDescription,maybeURL)  of
+          (Just desc, Just url)-> do
             H.br
             H.br
-            H.p $ H.toMarkup (
-              "Poseidon Community Archive (PCA) with per-paper packages and \
-              \genotype data as published." :: String)
+            H.p $ H.toMarkup desc
             H.footer $ H.p $ H.a
-              ! A.href "https://github.com/poseidon-framework/community-archive"
+              ! A.href (H.stringValue url)
               ! A.style "float: right; font-size: 0.8em;" $
-              H.toMarkup ("The PCA on GitHub" :: String)
-          "minotaur-archive" -> do
-            H.br
-            H.br
-            H.p $ H.toMarkup (
-              "Poseidon Minotaur Archive (PMA) with per-paper packages and \
-              \genotype data reprocessed by the Minotaur workflow." :: String)
-            H.footer $ H.p $ H.a
-              ! A.href "https://github.com/poseidon-framework/minotaur-archive"
-              ! A.style "float: right; font-size: 0.8em;" $
-              H.toMarkup ("The PMA on GitHub" :: String)
-          "aadr-archive" -> do
-            H.br
-            H.br
-            H.p $ H.toMarkup (
-              "Poseidon AADR Archive (PAA) with a structurally unified version of the \
-              \AADR dataset repackaged in the Poseidon package format." :: String)
-            H.footer $ H.p $ H.a
-              ! A.href "https://github.com/poseidon-framework/aadr-archive"
-              ! A.style "float: right; font-size: 0.8em;" $
-              H.toMarkup ("The PAA on GitHub" :: String)
+              H.toMarkup ("Source archive" :: String)
           _ -> return ()
 
 archivePage ::

--- a/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
+++ b/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
@@ -20,7 +20,9 @@ import           Poseidon.CLI.List          (ListEntity (..), ListOptions (..),
 import           Poseidon.CLI.Rectify       (ChecksumsToRectify (..),
                                              PackageVersionUpdate (..),
                                              RectifyOptions (..), runRectify)
-import           Poseidon.CLI.Serve         (ServeOptions (..), runServer, ArchiveConfig (..), ArchiveSpec (..))
+import           Poseidon.CLI.Serve         (ArchiveConfig (..),
+                                             ArchiveSpec (..),
+                                             ServeOptions (..), runServer)
 import           Poseidon.CLI.Summarise     (SummariseOptions (..),
                                              runSummarise)
 import           Poseidon.CLI.Survey        (SurveyOptions (..), runSurvey)
@@ -1205,11 +1207,11 @@ archives = Left $ ArchiveConfig [
         "test/testDat/testPackages/ancient/Lamnidis_2018"
       , "test/testDat/testPackages/ancient/Lamnidis_2018_newVersion"
       , "test/testDat/testPackages/ancient/Wang_2020"
-      ] Nothing Nothing
+      ] Nothing Nothing Nothing False
     , ArchiveSpec "testArchive1" [
         "test/testDat/testPackages/ancient/Schiffels_2016"
       , "test/testDat/testPackages/ancient/Schmid_2028"
-      ] Nothing Nothing
+      ] Nothing Nothing Nothing False
     ]
 
  -- Note: We here use our test server (no SSL and different port). The reason is that

--- a/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
+++ b/test/PoseidonGoldenTests/GoldenTestsRunCommands.hs
@@ -20,7 +20,7 @@ import           Poseidon.CLI.List          (ListEntity (..), ListOptions (..),
 import           Poseidon.CLI.Rectify       (ChecksumsToRectify (..),
                                              PackageVersionUpdate (..),
                                              RectifyOptions (..), runRectify)
-import           Poseidon.CLI.Serve         (ServeOptions (..), runServer)
+import           Poseidon.CLI.Serve         (ServeOptions (..), runServer, ArchiveConfig (..), ArchiveSpec (..))
 import           Poseidon.CLI.Summarise     (SummariseOptions (..),
                                              runSummarise)
 import           Poseidon.CLI.Survey        (SurveyOptions (..), runSurvey)
@@ -1199,13 +1199,17 @@ testPipelineChronicleAndTimetravel testDir checkFilePath = do
     -- delete .git directory in chronicle to clean up in the end
     removeDirectoryRecursive (testDir </> "chronicle" </> ".git")
 
-archives :: [(String, FilePath)]
-archives = [
-      ("testArchive1", "test/testDat/testPackages/ancient/Lamnidis_2018")
-    , ("testArchive1", "test/testDat/testPackages/ancient/Lamnidis_2018_newVersion")
-    , ("testArchive2", "test/testDat/testPackages/ancient/Schiffels_2016")
-    , ("testArchive1", "test/testDat/testPackages/ancient/Wang_2020")
-    , ("testArchive2", "test/testDat/testPackages/ancient/Schmid_2028")
+archives :: Either ArchiveConfig FilePath
+archives = Left $ ArchiveConfig [
+      ArchiveSpec "testArchive1" [
+        "test/testDat/testPackages/ancient/Lamnidis_2018"
+      , "test/testDat/testPackages/ancient/Lamnidis_2018_newVersion"
+      , "test/testDat/testPackages/ancient/Wang_2020"
+      ] Nothing Nothing
+    , ArchiveSpec "testArchive1" [
+        "test/testDat/testPackages/ancient/Schiffels_2016"
+      , "test/testDat/testPackages/ancient/Schmid_2028"
+      ] Nothing Nothing
     ]
 
  -- Note: We here use our test server (no SSL and different port). The reason is that


### PR DESCRIPTION
So here is a draft for the changes you proposed in your review for #327, @stschiff.

An `--archiveConfigFile` could e.g. look like this (just to show the structure):

```yml
archives:
- name: community-archive
  paths: [2010_RasmussenNature,2012_MeyerScience]
  description: test
  URL: https://github.com/poseidon-framework/community-archive
  dataURL: https://github.com/poseidon-framework/community-archive/tree/master
  zip: TRUE
- name: minotaur-archive
  paths: [2010_RasmussenNature,2012_MeyerScience]
  description: test
  URL: https://github.com/poseidon-framework/minotaur_archive
  dataURL: https://github.com/poseidon-framework/minotaur_archive/tree/master
  zip: TRUE
```