### PR TITLE
Added a mechanism to report non-breaking issues in individual cells of .janno and .ssf files

### DIFF
--- a/src/Poseidon/CLI/Survey.hs
+++ b/src/Poseidon/CLI/Survey.hs
@@ -1,8 +1,8 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- the following ones are necessary for the generics-sop magic
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs             #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators     #-}
 
 module Poseidon.CLI.Survey where

--- a/src/Poseidon/ColumnTypesJanno.hs
+++ b/src/Poseidon/ColumnTypesJanno.hs
@@ -198,7 +198,11 @@ instance Makeable JannoDateC14UncalBP where
             Left e -> fail $ "Date_C14_Uncal_BP can not be converted to Int because " ++ e
             Right (num, "") -> pure $ JannoDateC14UncalBP num
             Right (_, rest) -> fail $ "Date_C14_Uncal_BP can not be converted to Int, because of a trailing " ++ show rest
-instance Suspicious JannoDateC14UncalBP where inspect _ = Nothing
+instance Suspicious JannoDateC14UncalBP where
+    inspect (JannoDateC14UncalBP x)
+        | x >= 60000 = Just ["Date_C14_Uncal_BP is " ++ show x ++", so >60k years and thus beyond the \
+                             \pratical limit of radiocarbon dating."]
+        | otherwise = Nothing
 instance Show JannoDateC14UncalBP where          show (JannoDateC14UncalBP x) = show x
 instance Csv.ToField JannoDateC14UncalBP where   toField (JannoDateC14UncalBP x) = Csv.toField x
 instance Csv.FromField JannoDateC14UncalBP where parseField = parseTypeCSV "Date_C14_Uncal_BP"
@@ -334,7 +338,9 @@ instance Makeable JannoCaptureType where
         | x == "OtherCapture"       = pure OtherCapture
         | x == "ReferenceGenome"    = pure ReferenceGenome
         | otherwise = fail $ "Capture_Type is set to " ++ show x ++ ". " ++
-                             "That is not in the allowed set [Shotgun, 1240K, ArborComplete, ArborPrimePlus, ArborAncestralPlus, TwistAncientDNA, OtherCapture, ReferenceGenome]."
+                             "That is not in the allowed set [Shotgun, 1240K, ArborComplete, \
+                             \ArborPrimePlus, ArborAncestralPlus, TwistAncientDNA, OtherCapture, \
+                             \ReferenceGenome]."
 instance Suspicious JannoCaptureType where inspect _ = Nothing
 instance Show JannoCaptureType where
     show Shotgun            = "Shotgun"
@@ -458,7 +464,10 @@ instance Makeable JannoNrSNPs where
                 then fail $ "Nr_SNPs " ++ show x ++ " lower than 0, which is not meaningful."
                 else pure $ JannoNrSNPs num
             Right (_, rest) -> fail $ "Nr_SNPs can not be converted to Int, because of a trailing " ++ show rest
-instance Suspicious JannoNrSNPs where inspect _ = Nothing
+instance Suspicious JannoNrSNPs where
+    inspect (JannoNrSNPs x)
+        | x == 0 = Just ["Nr_SNPs is set to 0, indicating no recorded SNPs in the genotype data."]
+        | otherwise = Nothing
 instance Show JannoNrSNPs where          show (JannoNrSNPs x) = show x
 instance Csv.ToField JannoNrSNPs where   toField (JannoNrSNPs x) = Csv.toField x
 instance Csv.FromField JannoNrSNPs where parseField = parseTypeCSV "Nr_SNPs"

--- a/src/Poseidon/ColumnTypesJanno.hs
+++ b/src/Poseidon/ColumnTypesJanno.hs
@@ -26,6 +26,7 @@ instance Makeable GeneticSex where
         | x == "U"  = pure (GeneticSex Unknown)
         | otherwise = fail $ "Genetic_Sex is set to " ++ show x ++ ". " ++
                              "That is not in the allowed set [F, M, U]."
+instance Suspicious GeneticSex where inspect _ = Nothing
 instance Show GeneticSex where
     show (GeneticSex Female)  = "F"
     show (GeneticSex Male)    = "M"
@@ -77,6 +78,7 @@ instance Makeable JannoRelationDegree where
         | x == "other"        = pure OtherDegree
         | otherwise           = fail $ "Relation_Degree is set to " ++ show x ++ ". " ++
                                        "That is not in the allowed set [identical, first, second, thirdToFifth, sixthToTenth, other]."
+instance Suspicious JannoRelationDegree where inspect _ = Nothing
 instance Show JannoRelationDegree where
     show Identical    = "identical"
     show First        = "first"
@@ -115,6 +117,7 @@ instance Makeable JannoCountryISO where
             "Country_ISO is set to " ++ show x ++ ". " ++
             "That is not a valid ISO-alpha2 code describing an existing country."
         Just c  -> return $ JannoCountryISO c
+instance Suspicious JannoCountryISO where inspect _ = Nothing
 instance Csv.ToField JannoCountryISO where   toField x = Csv.toField $ show x
 instance Csv.FromField JannoCountryISO where parseField = parseTypeCSV "Country_ISO"
 
@@ -138,6 +141,7 @@ instance Makeable JannoLatitude where
                 then pure (JannoLatitude num)
                 else fail $ "Latitude " ++ show x ++ " not between -90 and 90"
             Right (_, rest) -> fail $ "Latitude can not be converted to Double, because of a trailing " ++ show rest
+instance Suspicious JannoLatitude where inspect _ = Nothing
 instance Show JannoLatitude where          show (JannoLatitude x) = show x
 instance Csv.ToField JannoLatitude where   toField (JannoLatitude x) = Csv.toField x
 instance Csv.FromField JannoLatitude where parseField = parseTypeCSV "Latitude"
@@ -154,6 +158,7 @@ instance Makeable JannoLongitude where
                 then pure (JannoLongitude num)
                 else fail $ "Longitude " ++ show x ++ " not between -180 and 180"
             Right (_, rest) -> fail $ "Longitude can not be converted to Double, because of a trailing " ++ show rest
+instance Suspicious JannoLongitude where inspect _ = Nothing
 instance Show JannoLongitude where          show (JannoLongitude x) = show x
 instance Csv.ToField JannoLongitude where   toField (JannoLongitude x) = Csv.toField x
 instance Csv.FromField JannoLongitude where parseField = parseTypeCSV "Longitude"
@@ -172,6 +177,7 @@ instance Makeable JannoDateType where
         | x == "modern"     = pure Modern
         | otherwise         = fail $ "Date_Type is set to " ++ show x ++ ". " ++
                                      "That is not in the allowed set [C14, contextual, modern]."
+instance Suspicious JannoDateType where inspect _ = Nothing
 instance Show JannoDateType where
     show C14        = "C14"
     show Contextual = "contextual"
@@ -192,6 +198,7 @@ instance Makeable JannoDateC14UncalBP where
             Left e -> fail $ "Date_C14_Uncal_BP can not be converted to Int because " ++ e
             Right (num, "") -> pure $ JannoDateC14UncalBP num
             Right (_, rest) -> fail $ "Date_C14_Uncal_BP can not be converted to Int, because of a trailing " ++ show rest
+instance Suspicious JannoDateC14UncalBP where inspect _ = Nothing
 instance Show JannoDateC14UncalBP where          show (JannoDateC14UncalBP x) = show x
 instance Csv.ToField JannoDateC14UncalBP where   toField (JannoDateC14UncalBP x) = Csv.toField x
 instance Csv.FromField JannoDateC14UncalBP where parseField = parseTypeCSV "Date_C14_Uncal_BP"
@@ -205,6 +212,7 @@ instance Makeable JannoDateC14UncalBPErr where
             Left e -> fail $ "Date_C14_Uncal_BP_Err can not be converted to Int because " ++ e
             Right (num, "") -> pure $ JannoDateC14UncalBPErr num
             Right (_, rest) -> fail $ "Date_C14_Uncal_BP_Err can not be converted to Int, because of a trailing " ++ show rest
+instance Suspicious JannoDateC14UncalBPErr where inspect _ = Nothing
 instance Show JannoDateC14UncalBPErr where          show (JannoDateC14UncalBPErr x) = show x
 instance Csv.ToField JannoDateC14UncalBPErr where   toField (JannoDateC14UncalBPErr x) = Csv.toField x
 instance Csv.FromField JannoDateC14UncalBPErr where parseField = parseTypeCSV "Date_C14_Uncal_BP_Err"
@@ -223,6 +231,7 @@ instance Makeable JannoDateBCADStart where
                    "Did you accidentally enter a BP date?"
                 else pure $ JannoDateBCADStart num
             Right (_, rest) -> fail $ "Date_BC_AD_Start can not be converted to Int, because of a trailing " ++ show rest
+instance Suspicious JannoDateBCADStart where inspect _ = Nothing
 instance Show JannoDateBCADStart where          show (JannoDateBCADStart x) = show x
 instance Csv.ToField JannoDateBCADStart where   toField (JannoDateBCADStart x) = Csv.toField x
 instance Csv.FromField JannoDateBCADStart where parseField = parseTypeCSV "Date_BC_AD_Start"
@@ -241,6 +250,7 @@ instance Makeable JannoDateBCADMedian where
                    "Did you accidentally enter a BP date?"
                 else pure $ JannoDateBCADMedian num
             Right (_, rest) -> fail $ "Date_BC_AD_Median can not be converted to Int, because of a trailing " ++ show rest
+instance Suspicious JannoDateBCADMedian where inspect _ = Nothing
 instance Show JannoDateBCADMedian where          show (JannoDateBCADMedian x) = show x
 instance Csv.ToField JannoDateBCADMedian where   toField (JannoDateBCADMedian x) = Csv.toField x
 instance Csv.FromField JannoDateBCADMedian where parseField = parseTypeCSV "Date_BC_AD_Median"
@@ -259,6 +269,7 @@ instance Makeable JannoDateBCADStop where
                    "Did you accidentally enter a BP date?"
                 else pure $ JannoDateBCADStop num
             Right (_, rest) -> fail $ "Date_BC_AD_Stop can not be converted to Int, because of a trailing " ++ show rest
+instance Suspicious JannoDateBCADStop where inspect _ = Nothing
 instance Show JannoDateBCADStop where          show (JannoDateBCADStop x) = show x
 instance Csv.ToField JannoDateBCADStop where   toField (JannoDateBCADStop x) = Csv.toField x
 instance Csv.FromField JannoDateBCADStop where parseField = parseTypeCSV "Date_BC_AD_Stop"
@@ -291,6 +302,7 @@ instance Makeable JannoNrLibraries where
                 then fail $ "Nr_Libraries " ++ show x ++ " lower than 1, which is impossible."
                 else pure $ JannoNrLibraries num
             Right (_, rest) -> fail $ "Nr_Libraries can not be converted to Int, because of a trailing " ++ show rest
+instance Suspicious JannoNrLibraries where inspect _ = Nothing
 instance Show JannoNrLibraries where          show (JannoNrLibraries x) = show x
 instance Csv.ToField JannoNrLibraries where   toField (JannoNrLibraries x) = Csv.toField x
 instance Csv.FromField JannoNrLibraries where parseField = parseTypeCSV "Nr_Libraries"
@@ -323,6 +335,7 @@ instance Makeable JannoCaptureType where
         | x == "ReferenceGenome"    = pure ReferenceGenome
         | otherwise = fail $ "Capture_Type is set to " ++ show x ++ ". " ++
                              "That is not in the allowed set [Shotgun, 1240K, ArborComplete, ArborPrimePlus, ArborAncestralPlus, TwistAncientDNA, OtherCapture, ReferenceGenome]."
+instance Suspicious JannoCaptureType where inspect _ = Nothing
 instance Show JannoCaptureType where
     show Shotgun            = "Shotgun"
     show A1240K             = "1240K"
@@ -351,6 +364,7 @@ instance Makeable JannoUDG where
         | x == "mixed" = pure Mixed
         | otherwise    = fail $ "UDG is set to " ++ show x ++ ". " ++
                                 "That is not in the allowed set [minus, half, plus, mixed]."
+instance Suspicious JannoUDG where inspect _ = Nothing
 instance Show JannoUDG where
     show Minus = "minus"
     show Half  = "half"
@@ -375,6 +389,7 @@ instance Makeable JannoLibraryBuilt where
         | x == "other" = pure Other
         | otherwise    = fail $ "Library_Built is set to " ++ show x ++ ". " ++
                                 "That is not in the allowed set [ds, ss, mixed]."
+instance Suspicious JannoLibraryBuilt where inspect _ = Nothing
 instance Show JannoLibraryBuilt where
     show DS        = "ds"
     show SS        = "ss"
@@ -395,6 +410,7 @@ instance Makeable JannoGenotypePloidy where
         | x == "haploid" = pure Haploid
         | otherwise      = fail $ "Genotype_Ploidy is set to " ++ show x ++ ". " ++
                                   "That is not in the allowed set [diploid, haploid]."
+instance Suspicious JannoGenotypePloidy where inspect _ = Nothing
 instance Show JannoGenotypePloidy where
     show Diploid = "diploid"
     show Haploid = "haploid"
@@ -408,6 +424,7 @@ instance Makeable JannoDataPreparationPipelineURL where
     make x
         | isURIReference (T.unpack x) = pure $ JannoDataPreparationPipelineURL x
         | otherwise                   = fail $ "Data_Preparation_Pipeline_URL " ++ show x ++ " is not a well structured URI."
+instance Suspicious JannoDataPreparationPipelineURL where inspect _ = Nothing
 instance Show JannoDataPreparationPipelineURL where          show (JannoDataPreparationPipelineURL x) = T.unpack x
 instance Csv.ToField JannoDataPreparationPipelineURL where   toField (JannoDataPreparationPipelineURL x) = Csv.toField x
 instance Csv.FromField JannoDataPreparationPipelineURL where parseField = parseTypeCSV "Data_Preparation_Pipeline_URL"
@@ -424,6 +441,7 @@ instance Makeable JannoEndogenous where
                 then pure (JannoEndogenous num)
                 else fail $ "Endogenous " ++ show x ++ " not between 0 and 100."
             Right (_, rest) -> fail $ "Endogenous can not be converted to Double, because of a trailing " ++ show rest
+instance Suspicious JannoEndogenous where inspect _ = Nothing
 instance Show JannoEndogenous where          show (JannoEndogenous x) = show x
 instance Csv.ToField JannoEndogenous where   toField (JannoEndogenous x) = Csv.toField x
 instance Csv.FromField JannoEndogenous where parseField = parseTypeCSV "Endogenous"
@@ -440,6 +458,7 @@ instance Makeable JannoNrSNPs where
                 then fail $ "Nr_SNPs " ++ show x ++ " lower than 0, which is not meaningful."
                 else pure $ JannoNrSNPs num
             Right (_, rest) -> fail $ "Nr_SNPs can not be converted to Int, because of a trailing " ++ show rest
+instance Suspicious JannoNrSNPs where inspect _ = Nothing
 instance Show JannoNrSNPs where          show (JannoNrSNPs x) = show x
 instance Csv.ToField JannoNrSNPs where   toField (JannoNrSNPs x) = Csv.toField x
 instance Csv.FromField JannoNrSNPs where parseField = parseTypeCSV "Nr_SNPs"
@@ -453,6 +472,7 @@ instance Makeable JannoCoverageOnTargets where
             Left e -> fail $ "Coverage_on_Target_SNPs can not be converted to Double because " ++ e
             Right (num, "") ->  pure (JannoCoverageOnTargets num)
             Right (_, rest) -> fail $ "Coverage_on_Target_SNPs can not be converted to Double, because of a trailing " ++ show rest
+instance Suspicious JannoCoverageOnTargets where inspect _ = Nothing
 instance Show JannoCoverageOnTargets where          show (JannoCoverageOnTargets x) = show x
 instance Csv.ToField JannoCoverageOnTargets where   toField (JannoCoverageOnTargets x) = Csv.toField x
 instance Csv.FromField JannoCoverageOnTargets where parseField = parseTypeCSV "Coverage_on_Target_SNPs"
@@ -469,6 +489,7 @@ instance Makeable JannoDamage where
                 then pure (JannoDamage num)
                 else fail $ "Damage " ++ show x ++ " not between 0 and 100."
             Right (_, rest) -> fail $ "Damage can not be converted to Double, because of a trailing " ++ show rest
+instance Suspicious JannoDamage where inspect _ = Nothing
 instance Show JannoDamage where          show (JannoDamage x) = show x
 instance Csv.ToField JannoDamage where   toField (JannoDamage x) = Csv.toField x
 instance Csv.FromField JannoDamage where parseField = parseTypeCSV "Damage"
@@ -495,6 +516,7 @@ newtype JannoGeneticSourceAccessionID = JannoGeneticSourceAccessionID AccessionI
 
 instance Makeable JannoGeneticSourceAccessionID where
     make x = JannoGeneticSourceAccessionID <$> makeAccessionID x
+instance Suspicious JannoGeneticSourceAccessionID where inspect _ = Nothing
 instance Show JannoGeneticSourceAccessionID where
     show (JannoGeneticSourceAccessionID x) = show x
 instance Csv.ToField JannoGeneticSourceAccessionID where   toField x  = Csv.toField $ show x

--- a/src/Poseidon/ColumnTypesSSF.hs
+++ b/src/Poseidon/ColumnTypesSSF.hs
@@ -234,6 +234,8 @@ instance Makeable SSFReadCount where
             Left e -> fail $ "read_count can not be converted to Integer because " ++ e
             Right (num, "") -> pure $ SSFReadCount num
             Right (_, rest) -> fail $ "read_count can not be converted to Integer, because of a trailing " ++ show rest
+instance Suspicious SSFReadCount where
+    inspect (SSFReadCount x) | x < 0 = putStrLn "Fishy! Fishy! Fishy!"
 instance Show SSFReadCount where          show (SSFReadCount x) = show x
 instance Csv.ToField SSFReadCount where   toField (SSFReadCount x) = Csv.toField x
 instance Csv.FromField SSFReadCount where parseField = parseTypeCSV "read_count"

--- a/src/Poseidon/ColumnTypesSSF.hs
+++ b/src/Poseidon/ColumnTypesSSF.hs
@@ -6,6 +6,7 @@ module Poseidon.ColumnTypesSSF where
 
 import           Poseidon.AccessionIDs
 import           Poseidon.ColumnTypesUtils
+import Poseidon.Utils (logWarning)
 
 import           Data.Char                 (isHexDigit)
 import qualified Data.Csv                  as Csv
@@ -31,6 +32,7 @@ instance Makeable SSFUDG where
         | x == "plus"  = pure SSFPlus
         | otherwise    = fail $ "udg is set to " ++ show x ++ ". " ++
                                 "That is not in the allowed set [minus, half, plus]."
+instance Suspicious SSFUDG where inspect _ = pure ()
 instance Show SSFUDG where
     show SSFMinus = "minus"
     show SSFHalf  = "half"
@@ -50,6 +52,7 @@ instance Makeable SSFLibraryBuilt where
         | x == "ss"    = pure SSFSS
         | otherwise    = fail $ "library_built is set to " ++ show x ++ ". " ++
                                 "That is not in [ds, ss]."
+instance Suspicious SSFLibraryBuilt where inspect _ = pure ()
 instance Show SSFLibraryBuilt where
     show SSFDS = "ds"
     show SSFSS = "ss"
@@ -68,6 +71,7 @@ instance Makeable SSFAccessionIDSample where
             i@(INSDCSample _) -> return $ SSFAccessionIDSample i
             --i@(OtherID _) -> return $ SSFAccessionIDSample i
             i -> fail $ "sample_accession " ++ show i ++ " is not a correct biosample/sample accession."
+instance Suspicious SSFAccessionIDSample where inspect _ = pure ()
 instance Show SSFAccessionIDSample where
     show (SSFAccessionIDSample x) = show x
 instance Csv.ToField SSFAccessionIDSample where   toField x  = Csv.toField $ show x
@@ -85,6 +89,7 @@ instance Makeable SSFAccessionIDStudy where
             i@(INSDCStudy _) -> return $ SSFAccessionIDStudy i
             --i@(OtherID _) -> return $ SSFAccessionIDStudy i
             i -> fail $ "study_accession " ++ show i ++ " is not a correct project/study accession."
+instance Suspicious SSFAccessionIDStudy where inspect _ = pure ()
 instance Show SSFAccessionIDStudy where
     show (SSFAccessionIDStudy x) = show x
 instance Csv.ToField SSFAccessionIDStudy where   toField x  = Csv.toField $ show x
@@ -101,6 +106,7 @@ instance Makeable SSFAccessionIDRun where
             i@(INSDCRun _) -> return $ SSFAccessionIDRun i
             --i@(OtherID _) -> return $ SSFAccessionIDRun i
             i -> fail $ "run_accession " ++ show i ++ " is not a correct run accession."
+instance Suspicious SSFAccessionIDRun where inspect _ = pure ()
 instance Show SSFAccessionIDRun where
     show (SSFAccessionIDRun x) = show x
 instance Csv.ToField SSFAccessionIDRun where   toField x  = Csv.toField $ show x
@@ -124,6 +130,7 @@ instance Makeable SSFFirstPublicSimpleDate where
             Nothing -> fail $ "first_public date " ++ T.unpack x ++
                               " is not a correct date in the format YYYY-MM-DD."
             Just d  -> pure (SSFFirstPublicSimpleDate d)
+instance Suspicious SSFFirstPublicSimpleDate where inspect _ = pure ()
 instance Show SSFFirstPublicSimpleDate where
     show (SSFFirstPublicSimpleDate x) = formatTime defaultTimeLocale "%Y-%-m-%-d" x
 instance Csv.ToField SSFFirstPublicSimpleDate where
@@ -141,6 +148,7 @@ instance Makeable SSFLastUpdatedSimpleDate where
             Nothing -> fail $ "last_updated date " ++ T.unpack x ++
                               " is not a correct date in the format YYYY-MM-DD."
             Just d  -> pure (SSFLastUpdatedSimpleDate d)
+instance Suspicious SSFLastUpdatedSimpleDate where inspect _ = pure ()
 instance Show SSFLastUpdatedSimpleDate where
     show (SSFLastUpdatedSimpleDate x) = formatTime defaultTimeLocale "%Y-%-m-%-d" x
 instance Csv.ToField SSFLastUpdatedSimpleDate where
@@ -181,6 +189,7 @@ instance Makeable SSFFastqFTPURI where
         | isURIReference (T.unpack x) = pure $ SSFFastqFTPURI x
         | otherwise                   = fail $ "fastq_ftp entry " ++ show x ++
                                                " is not a well-structured URI."
+instance Suspicious SSFFastqFTPURI where inspect _ = pure ()
 instance Show SSFFastqFTPURI where show (SSFFastqFTPURI x) = T.unpack x
 instance Csv.ToField SSFFastqFTPURI where toField x = Csv.toField $ show x
 instance Csv.FromField SSFFastqFTPURI where parseField = parseTypeCSV "fastq_ftp"
@@ -194,6 +203,7 @@ instance Makeable SSFFastqASPERAURI where
         | isURIReference (T.unpack x) = pure $ SSFFastqASPERAURI x
         | otherwise                   = fail $ "fastq_aspera entry " ++ show x ++
                                                " is not a well-structured URI."
+instance Suspicious SSFFastqASPERAURI where inspect _ = pure ()
 instance Show SSFFastqASPERAURI where show (SSFFastqASPERAURI x) = T.unpack x
 instance Csv.ToField SSFFastqASPERAURI where toField x = Csv.toField $ show x
 instance Csv.FromField SSFFastqASPERAURI where parseField = parseTypeCSV "fastq_aspera"
@@ -207,6 +217,7 @@ instance Makeable SSFFastqBytes where
             Left e -> fail $ "fastq_bytes can not be converted to Integer because " ++ e
             Right (num, "") -> pure $ SSFFastqBytes num
             Right (_, rest) -> fail $ "fastq_bytes can not be converted to Integer, because of a trailing " ++ show rest
+instance Suspicious SSFFastqBytes where inspect _ = pure ()
 instance Show SSFFastqBytes where          show (SSFFastqBytes x) = show x
 instance Csv.ToField SSFFastqBytes where   toField (SSFFastqBytes x) = Csv.toField x
 instance Csv.FromField SSFFastqBytes where parseField = parseTypeCSV "fastq_bytes"
@@ -221,6 +232,7 @@ instance Makeable SSFFastqMD5 where
                                " does not contain a well-structured MD5 hash"
 isMD5Hash :: T.Text -> Bool
 isMD5Hash x = T.length x == 32 && T.all isHexDigit x
+instance Suspicious SSFFastqMD5 where inspect _ = pure ()
 instance Show SSFFastqMD5 where show (SSFFastqMD5 x) = T.unpack x
 instance Csv.ToField SSFFastqMD5 where   toField x = Csv.toField $ show x
 instance Csv.FromField SSFFastqMD5 where parseField = parseTypeCSV "fastq_md5"
@@ -235,7 +247,8 @@ instance Makeable SSFReadCount where
             Right (num, "") -> pure $ SSFReadCount num
             Right (_, rest) -> fail $ "read_count can not be converted to Integer, because of a trailing " ++ show rest
 instance Suspicious SSFReadCount where
-    inspect (SSFReadCount x) | x < 0 = putStrLn "Fishy! Fishy! Fishy!"
+    inspect (SSFReadCount x) | x < 0 = logWarning "Fishy! Fishy! Fishy!"
+                             | otherwise = pure ()
 instance Show SSFReadCount where          show (SSFReadCount x) = show x
 instance Csv.ToField SSFReadCount where   toField (SSFReadCount x) = Csv.toField x
 instance Csv.FromField SSFReadCount where parseField = parseTypeCSV "read_count"
@@ -249,6 +262,7 @@ instance Makeable SSFSubmittedFTPURI where
         | isURIReference (T.unpack x) = pure $ SSFSubmittedFTPURI x
         | otherwise                   = fail $ "submitted_ftp entry " ++ show x ++
                                                " is not a well-structured URI."
+instance Suspicious SSFSubmittedFTPURI where inspect _ = pure ()
 instance Show SSFSubmittedFTPURI where show (SSFSubmittedFTPURI x) = T.unpack x
 instance Csv.ToField SSFSubmittedFTPURI where toField x = Csv.toField $ show x
 instance Csv.FromField SSFSubmittedFTPURI where parseField = parseTypeCSV "submitted_ftp"

--- a/src/Poseidon/ColumnTypesSSF.hs
+++ b/src/Poseidon/ColumnTypesSSF.hs
@@ -6,7 +6,6 @@ module Poseidon.ColumnTypesSSF where
 
 import           Poseidon.AccessionIDs
 import           Poseidon.ColumnTypesUtils
-import Poseidon.Utils (logWarning)
 
 import           Data.Char                 (isHexDigit)
 import qualified Data.Csv                  as Csv
@@ -17,7 +16,6 @@ import           Data.Time.Format          (defaultTimeLocale, formatTime,
                                             parseTimeM)
 import           GHC.Generics              (Generic)
 import           Network.URI               (isURIReference)
-import Data.List as L
 
 -- | A datatype for the udg .ssf column
 data SSFUDG =

--- a/src/Poseidon/ColumnTypesSSF.hs
+++ b/src/Poseidon/ColumnTypesSSF.hs
@@ -17,6 +17,7 @@ import           Data.Time.Format          (defaultTimeLocale, formatTime,
                                             parseTimeM)
 import           GHC.Generics              (Generic)
 import           Network.URI               (isURIReference)
+import Data.List as L
 
 -- | A datatype for the udg .ssf column
 data SSFUDG =
@@ -32,7 +33,7 @@ instance Makeable SSFUDG where
         | x == "plus"  = pure SSFPlus
         | otherwise    = fail $ "udg is set to " ++ show x ++ ". " ++
                                 "That is not in the allowed set [minus, half, plus]."
-instance Suspicious SSFUDG where inspect _ = pure ()
+instance Suspicious SSFUDG where inspect _ = Nothing
 instance Show SSFUDG where
     show SSFMinus = "minus"
     show SSFHalf  = "half"
@@ -52,7 +53,7 @@ instance Makeable SSFLibraryBuilt where
         | x == "ss"    = pure SSFSS
         | otherwise    = fail $ "library_built is set to " ++ show x ++ ". " ++
                                 "That is not in [ds, ss]."
-instance Suspicious SSFLibraryBuilt where inspect _ = pure ()
+instance Suspicious SSFLibraryBuilt where inspect _ = Nothing
 instance Show SSFLibraryBuilt where
     show SSFDS = "ds"
     show SSFSS = "ss"
@@ -71,7 +72,7 @@ instance Makeable SSFAccessionIDSample where
             i@(INSDCSample _) -> return $ SSFAccessionIDSample i
             --i@(OtherID _) -> return $ SSFAccessionIDSample i
             i -> fail $ "sample_accession " ++ show i ++ " is not a correct biosample/sample accession."
-instance Suspicious SSFAccessionIDSample where inspect _ = pure ()
+instance Suspicious SSFAccessionIDSample where inspect _ = Nothing
 instance Show SSFAccessionIDSample where
     show (SSFAccessionIDSample x) = show x
 instance Csv.ToField SSFAccessionIDSample where   toField x  = Csv.toField $ show x
@@ -89,7 +90,7 @@ instance Makeable SSFAccessionIDStudy where
             i@(INSDCStudy _) -> return $ SSFAccessionIDStudy i
             --i@(OtherID _) -> return $ SSFAccessionIDStudy i
             i -> fail $ "study_accession " ++ show i ++ " is not a correct project/study accession."
-instance Suspicious SSFAccessionIDStudy where inspect _ = pure ()
+instance Suspicious SSFAccessionIDStudy where inspect _ = Nothing
 instance Show SSFAccessionIDStudy where
     show (SSFAccessionIDStudy x) = show x
 instance Csv.ToField SSFAccessionIDStudy where   toField x  = Csv.toField $ show x
@@ -106,7 +107,7 @@ instance Makeable SSFAccessionIDRun where
             i@(INSDCRun _) -> return $ SSFAccessionIDRun i
             --i@(OtherID _) -> return $ SSFAccessionIDRun i
             i -> fail $ "run_accession " ++ show i ++ " is not a correct run accession."
-instance Suspicious SSFAccessionIDRun where inspect _ = pure ()
+instance Suspicious SSFAccessionIDRun where inspect _ = Nothing
 instance Show SSFAccessionIDRun where
     show (SSFAccessionIDRun x) = show x
 instance Csv.ToField SSFAccessionIDRun where   toField x  = Csv.toField $ show x
@@ -130,7 +131,7 @@ instance Makeable SSFFirstPublicSimpleDate where
             Nothing -> fail $ "first_public date " ++ T.unpack x ++
                               " is not a correct date in the format YYYY-MM-DD."
             Just d  -> pure (SSFFirstPublicSimpleDate d)
-instance Suspicious SSFFirstPublicSimpleDate where inspect _ = pure ()
+instance Suspicious SSFFirstPublicSimpleDate where inspect _ = Nothing
 instance Show SSFFirstPublicSimpleDate where
     show (SSFFirstPublicSimpleDate x) = formatTime defaultTimeLocale "%Y-%-m-%-d" x
 instance Csv.ToField SSFFirstPublicSimpleDate where
@@ -148,7 +149,7 @@ instance Makeable SSFLastUpdatedSimpleDate where
             Nothing -> fail $ "last_updated date " ++ T.unpack x ++
                               " is not a correct date in the format YYYY-MM-DD."
             Just d  -> pure (SSFLastUpdatedSimpleDate d)
-instance Suspicious SSFLastUpdatedSimpleDate where inspect _ = pure ()
+instance Suspicious SSFLastUpdatedSimpleDate where inspect _ = Nothing
 instance Show SSFLastUpdatedSimpleDate where
     show (SSFLastUpdatedSimpleDate x) = formatTime defaultTimeLocale "%Y-%-m-%-d" x
 instance Csv.ToField SSFLastUpdatedSimpleDate where
@@ -189,7 +190,7 @@ instance Makeable SSFFastqFTPURI where
         | isURIReference (T.unpack x) = pure $ SSFFastqFTPURI x
         | otherwise                   = fail $ "fastq_ftp entry " ++ show x ++
                                                " is not a well-structured URI."
-instance Suspicious SSFFastqFTPURI where inspect _ = pure ()
+instance Suspicious SSFFastqFTPURI where inspect _ = Nothing
 instance Show SSFFastqFTPURI where show (SSFFastqFTPURI x) = T.unpack x
 instance Csv.ToField SSFFastqFTPURI where toField x = Csv.toField $ show x
 instance Csv.FromField SSFFastqFTPURI where parseField = parseTypeCSV "fastq_ftp"
@@ -203,7 +204,7 @@ instance Makeable SSFFastqASPERAURI where
         | isURIReference (T.unpack x) = pure $ SSFFastqASPERAURI x
         | otherwise                   = fail $ "fastq_aspera entry " ++ show x ++
                                                " is not a well-structured URI."
-instance Suspicious SSFFastqASPERAURI where inspect _ = pure ()
+instance Suspicious SSFFastqASPERAURI where inspect _ = Nothing
 instance Show SSFFastqASPERAURI where show (SSFFastqASPERAURI x) = T.unpack x
 instance Csv.ToField SSFFastqASPERAURI where toField x = Csv.toField $ show x
 instance Csv.FromField SSFFastqASPERAURI where parseField = parseTypeCSV "fastq_aspera"
@@ -217,7 +218,7 @@ instance Makeable SSFFastqBytes where
             Left e -> fail $ "fastq_bytes can not be converted to Integer because " ++ e
             Right (num, "") -> pure $ SSFFastqBytes num
             Right (_, rest) -> fail $ "fastq_bytes can not be converted to Integer, because of a trailing " ++ show rest
-instance Suspicious SSFFastqBytes where inspect _ = pure ()
+instance Suspicious SSFFastqBytes where inspect _ = Nothing
 instance Show SSFFastqBytes where          show (SSFFastqBytes x) = show x
 instance Csv.ToField SSFFastqBytes where   toField (SSFFastqBytes x) = Csv.toField x
 instance Csv.FromField SSFFastqBytes where parseField = parseTypeCSV "fastq_bytes"
@@ -232,7 +233,7 @@ instance Makeable SSFFastqMD5 where
                                " does not contain a well-structured MD5 hash"
 isMD5Hash :: T.Text -> Bool
 isMD5Hash x = T.length x == 32 && T.all isHexDigit x
-instance Suspicious SSFFastqMD5 where inspect _ = pure ()
+instance Suspicious SSFFastqMD5 where inspect _ = Nothing
 instance Show SSFFastqMD5 where show (SSFFastqMD5 x) = T.unpack x
 instance Csv.ToField SSFFastqMD5 where   toField x = Csv.toField $ show x
 instance Csv.FromField SSFFastqMD5 where parseField = parseTypeCSV "fastq_md5"
@@ -247,8 +248,8 @@ instance Makeable SSFReadCount where
             Right (num, "") -> pure $ SSFReadCount num
             Right (_, rest) -> fail $ "read_count can not be converted to Integer, because of a trailing " ++ show rest
 instance Suspicious SSFReadCount where
-    inspect (SSFReadCount x) | x < 0 = logWarning "Fishy! Fishy! Fishy!"
-                             | otherwise = pure ()
+    inspect (SSFReadCount x) | x == -1 = Just ["read_count is set to -1, which may indicate a missing value"]
+                             | otherwise = pure []
 instance Show SSFReadCount where          show (SSFReadCount x) = show x
 instance Csv.ToField SSFReadCount where   toField (SSFReadCount x) = Csv.toField x
 instance Csv.FromField SSFReadCount where parseField = parseTypeCSV "read_count"
@@ -262,7 +263,7 @@ instance Makeable SSFSubmittedFTPURI where
         | isURIReference (T.unpack x) = pure $ SSFSubmittedFTPURI x
         | otherwise                   = fail $ "submitted_ftp entry " ++ show x ++
                                                " is not a well-structured URI."
-instance Suspicious SSFSubmittedFTPURI where inspect _ = pure ()
+instance Suspicious SSFSubmittedFTPURI where inspect _ = Nothing
 instance Show SSFSubmittedFTPURI where show (SSFSubmittedFTPURI x) = T.unpack x
 instance Csv.ToField SSFSubmittedFTPURI where toField x = Csv.toField $ show x
 instance Csv.FromField SSFSubmittedFTPURI where parseField = parseTypeCSV "submitted_ftp"

--- a/src/Poseidon/ColumnTypesUtils.hs
+++ b/src/Poseidon/ColumnTypesUtils.hs
@@ -2,15 +2,13 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs             #-}
-{-# LANGUAGE TypeOperators     #-}
+-- the following ones are necessary for the generics-sop magic
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module Poseidon.ColumnTypesUtils where
-import Poseidon.Utils (PoseidonIO)
 
 import           Data.ByteString       as S
 import qualified Data.ByteString.Char8 as Bchs
@@ -21,18 +19,15 @@ import qualified Data.List             as L
 import qualified Data.Text             as T
 import qualified Data.Text.Encoding    as T
 import           Data.Typeable         (Typeable)
-import           GHC.Generics          as G
+import           Generics.SOP          (All, Generic (Code, from),
+                                        HCollapse (hcollapse), I (..), K (K),
+                                        Proxy (..), hcmap, unSOP, unZ)
+import           GHC.Generics          as G hiding (conName)
 import           Language.Haskell.TH   (Con (..), Dec (..), DecsQ, Info (..),
                                         Name, conE, conP, conT, mkName, reify,
                                         varE, varP)
 import qualified Text.Parsec           as P
 import qualified Text.Parsec.String    as P
-
-import           Generics.SOP              (All, Generic (Code, from),
-                                            HCollapse (hcollapse),
-                                            HPure (hpure), I (..), K (K), NP,
-                                            Proxy (..), SListI, hcmap, hzipWith,
-                                            unI, unSOP, unZ)
 
 -- a typeclass for types with smart constructors
 class Makeable a where
@@ -45,7 +40,7 @@ class Suspicious a where
 instance Suspicious String where
     inspect _ = Nothing
 instance Suspicious a => Suspicious (Maybe a) where
-    inspect Nothing = Nothing
+    inspect Nothing  = Nothing
     inspect (Just x) = inspect x
 instance Suspicious a => Suspicious (ListColumn a) where
     inspect (ListColumn xs) = L.concat <$> mapM inspect xs

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -124,6 +124,9 @@ data JannoRow = JannoRow
     }
     deriving (Show, Eq, Generic)
 
+-- deriving with TemplateHaskell necessary for the generics magic in the Survey module
+deriveGeneric ''JannoRow
+
 -- This header also defines the output column order when writing to csv!
 jannoHeader :: [Bchs.ByteString]
 jannoHeader = [
@@ -514,9 +517,6 @@ checkRelationColsConsistent x =
         False -> E.throwError "Relation_To, Relation_Degree and Relation_Type \
                       \do not have the same lengths. Relation_Type can be empty"
         True  -> return x
-
--- deriving with TemplateHaskell necessary for the generics magic in the Survey module
-deriveGeneric ''JannoRow
 
 -- | a convenience function to construct Eigenstrat Ind entries out of jannoRows
 jannoRows2EigenstratIndEntries :: JannoRows -> [EigenstratIndEntry]

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
--- the following three are necessary for deriveGeneric
+-- the following ones are necessary for the generics-sop magic (deriveGeneric)
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeFamilies        #-}
@@ -26,6 +26,7 @@ import           Poseidon.Utils
 
 import           Control.Exception                    (throwIO)
 import           Control.Monad                        (unless, when)
+import qualified Control.Monad                        as OP
 import qualified Control.Monad.Except                 as E
 import           Control.Monad.IO.Class               (liftIO)
 import qualified Control.Monad.Writer                 as W
@@ -38,7 +39,7 @@ import qualified Data.HashMap.Strict                  as HM
 import           Data.List                            (elemIndex, foldl',
                                                        intercalate, nub, sort,
                                                        transpose, (\\))
-import           Data.Maybe                           (fromJust, catMaybes)
+import           Data.Maybe                           (catMaybes, fromJust)
 import qualified Data.Text                            as T
 import qualified Data.Vector                          as V
 import           Generics.SOP.TH                      (deriveGeneric)
@@ -46,7 +47,6 @@ import           GHC.Generics                         (Generic)
 import           Options.Applicative.Help.Levenshtein (editDistance)
 import           SequenceFormats.Eigenstrat           (EigenstratIndEntry (..))
 import qualified Text.Parsec                          as P
-import qualified Control.Monad as OP
 
 -- | A  data type to represent a janno file
 newtype JannoRows = JannoRows {getJannoRows :: [JannoRow]}

--- a/src/Poseidon/SequencingSource.hs
+++ b/src/Poseidon/SequencingSource.hs
@@ -231,11 +231,19 @@ readSeqSourceFileRow seqSourcePath (lineNumber, row) = do
                     Right result -> renderCsvParseError result
             return $ Left $ PoseidonFileRowException seqSourcePath (show lineNumber) betterError
         Right seqSourceRow -> do
+            -- cell-wise checks
             let inspectRes = concat $ catMaybes $ inspectEachField seqSourceRow
             OP.unless (null inspectRes) $ do
-                logWarning $ "Anomalies in row " ++ show lineNumber ++ " in " ++ seqSourcePath ++ ": "
+                logWarning $ "Value anomaly in " ++ seqSourcePath ++ " in line " ++ renderLocation ++ ": "
                 mapM_ logWarning inspectRes
+            -- return result
             return $ Right seqSourceRow
+            where
+                renderWarning :: String -> String
+                renderWarning e = "Cross-column anomaly in " ++ seqSourcePath ++ " " ++
+                                  "in line " ++ renderLocation ++ ": " ++ e
+                renderLocation :: String
+                renderLocation =  show lineNumber
 
 -- Global SSF consistency checks
 

--- a/src/Poseidon/SequencingSource.hs
+++ b/src/Poseidon/SequencingSource.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
--- the following three are necessary for deriveGeneric
+-- the following ones are necessary for the generics-sop magic (deriveGeneric)
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeFamilies        #-}
@@ -14,6 +14,7 @@ import           Poseidon.Utils
 
 import           Control.Exception          (throwIO)
 import           Control.Monad              (unless, when)
+import qualified Control.Monad              as OP
 import           Control.Monad.IO.Class     (liftIO)
 import           Data.Bifunctor             (second)
 import qualified Data.ByteString.Char8      as Bchs
@@ -22,12 +23,11 @@ import qualified Data.Csv                   as Csv
 import           Data.Either                (lefts, rights)
 import qualified Data.HashMap.Strict        as HM
 import           Data.List                  (foldl', nub, sort)
-import           Data.Maybe                 (isJust, mapMaybe, catMaybes)
+import           Data.Maybe                 (catMaybes, isJust, mapMaybe)
 import qualified Data.Vector                as V
+import           Generics.SOP.TH            (deriveGeneric)
 import           GHC.Generics               (Generic)
 import qualified Text.Parsec                as P
-import           Generics.SOP.TH                      (deriveGeneric)
-import qualified Control.Monad as OP
 
 -- | A data type to represent a seqSourceFile
 newtype SeqSourceRows = SeqSourceRows {getSeqSourceRowList :: [SeqSourceRow]}
@@ -239,9 +239,6 @@ readSeqSourceFileRow seqSourcePath (lineNumber, row) = do
             -- return result
             return $ Right seqSourceRow
             where
-                renderWarning :: String -> String
-                renderWarning e = "Cross-column anomaly in " ++ seqSourcePath ++ " " ++
-                                  "in line " ++ renderLocation ++ ": " ++ e
                 renderLocation :: String
                 renderLocation =  show lineNumber
 

--- a/src/Poseidon/SequencingSource.hs
+++ b/src/Poseidon/SequencingSource.hs
@@ -230,7 +230,7 @@ readSeqSourceFileRow seqSourcePath (lineNumber, row) = do
                     Right result -> renderCsvParseError result
             return $ Left $ PoseidonFileRowException seqSourcePath (show lineNumber) betterError
         Right seqSourceRow -> do
-            liftIO $ inspectEachField seqSourceRow
+            inspectEachField seqSourceRow
             return $ Right seqSourceRow
 
 -- Global SSF consistency checks


### PR DESCRIPTION
Multiple times over the past years we have discussed the requirement to report not just parsing failure when reading .janno or .ssf, but also minor non-breaking issues in individual cells. With the upcoming switch to Poseidon v3.0.0 we will probably encounter more cases where we would like to do this.

From a technical point of view this is not trivial. The cassava library we use for parsing does not operate in IO (rightfully so, I guess) and does not allow logging in the reading process. We already have a slightly awkward mechanism check for cross-column consistency after the reading (see e.g. at the bottom of the `Janno` module) and potentially this could have been extended to individual columns. But I find this inelegant and hard to maintain.

Here I propose an alternative solution with a custom type class `Suspicious` for types that should be inspected for anomalies after parsing.

```haskell
class Suspicious a where
    inspect :: a -> Maybe [String]
```

All .janno and .ssf types are suspicious, so they must all be implement as instances of this class. I did so in this PR, and already came up with some useful instances, e.g. to solve #350:

```haskell
instance Suspicious SSFAccessionIDSample where
    inspect (SSFAccessionIDSample x) =
        case x of
            (INSDCBioSample _) -> Nothing
            (INSDCSample _)    -> Nothing
            i                  -> Just ["sample_accession " ++ show i ++ " is not a correct INSDC \
                                         \biosample/sample accession."]
```

or to demarcate "soft" limits:

```haskell
instance Suspicious JannoDateC14UncalBP where
    inspect (JannoDateC14UncalBP x)
        | x >= 60000 = Just ["Date_C14_Uncal_BP is " ++ show x ++", so >60k years and thus beyond the \
                             \pratical limit of radiocarbon dating."]
        | otherwise = Nothing
```

I'm sure we will come up with more.

All of these inspections are performed in `readJannoFileRow` and `readSeqSourceFileRow` respectively, so directly after parsing each row.

```haskell
-- cell-wise checks
let inspectRes = concat $ catMaybes $ inspectEachField jannoRow
OP.unless (null inspectRes) $ do
    logWarning $ "Value anomaly in " ++ jannoPath ++ " in line " ++ renderLocation ++ ": "
    mapM_ logWarning inspectRes
```

The key function `inspectEachField` here is horrible generics-sop magic looping through all record fields of `JannoRow` and `SeqSourceRow`:

```haskell
inspectEachField :: (Generics.SOP.Generic a, Code a ~ '[ xs ], All Suspicious xs) => a -> [Maybe [String]]
inspectEachField =
      hcollapse
    . hcmap (Proxy :: Proxy Suspicious) (\(I x) -> K $ inspect x)
    . unZ . unSOP . Generics.SOP.from
```

Issues are reported on the command line like this:

```
[Info]    Initializing packages...
[Warning] Value anomaly in ./Ning_China.janno in line 21 (Poseidon_ID: JXNTM23):
[Warning] Date_C14_Uncal_BP is 3127000, so >60k years and thus beyond the pratical limit of radiocarbon dating.
[Warning] Nr_SNPs is set to 0, indicating no recorded SNPs in the genotype data.
[Warning] Value anomaly in ./ENAtable.ssf in line 5:
[Warning] sample_accession SAMA6490835 is not a correct INSDC biosample/sample accession.
[Warning] Value anomaly in ./ENAtable.ssf in line 9:
[Warning] study_accession 3 is not a correct INSDC project/study accession.
[Warning] run_accession s is not a correct INSDC run accession.
[Warning] Value anomaly in ./ENAtable.ssf in line 39:
[Warning] read_count is set to -1, which indicates a missing value.
[Info]    Packages loaded: 1
```



I think this is neat. What do you think, @stschiff? I'm also happy to hear suggestions for additional warnings, @TCLamnidis.