### PR TITLE
Making arbitrary columns in .janno and .ssf mandatory with a command line flag

### DIFF
--- a/src/Poseidon/CLI/Jannocoalesce.hs
+++ b/src/Poseidon/CLI/Jannocoalesce.hs
@@ -4,6 +4,7 @@
 module Poseidon.CLI.Jannocoalesce where
 
 import           Poseidon.Janno         (JannoRow (..), JannoRows (..),
+                                         parseJannoRowFromNamedRecord,
                                          readJannoFile, writeJannoFile)
 import           Poseidon.Package       (PackageReadOptions (..),
                                          defaultPackageReadOptions,
@@ -20,6 +21,7 @@ import qualified Data.Csv               as Csv
 import qualified Data.HashMap.Strict    as HM
 import qualified Data.IORef             as R
 import           Data.List              ((\\))
+import qualified Data.Set               as S
 import           Data.Text              (pack, replace, unpack)
 import           System.Directory       (createDirectoryIfMissing)
 import           System.FilePath        (takeDirectory)
@@ -122,7 +124,7 @@ mergeRow cp targetRow sourceRow fields overwrite sKey tKey = do
         -- fill in the target row with dummy values for desired fields that might not be present yet
         targetComplete    = HM.union targetRowRecord (HM.fromList $ map (, BSC.empty) sourceKeysDesired)
         newRowRecord      = HM.mapWithKey fillFromSource targetComplete
-        parseResult       = Csv.runParser . Csv.parseNamedRecord $ newRowRecord
+        parseResult       = Csv.runParser . (parseJannoRowFromNamedRecord S.empty) $ newRowRecord
     logInfo $ "matched target " ++ BSC.unpack (targetComplete  HM.! BSC.pack tKey) ++
               " with source "   ++ BSC.unpack (sourceRowRecord HM.! BSC.pack sKey)
     case parseResult of

--- a/src/Poseidon/Janno.hs
+++ b/src/Poseidon/Janno.hs
@@ -17,7 +17,8 @@ module Poseidon.Janno (
     jannoHeaderString,
     JannoRows (..),
     jannoRows2EigenstratIndEntries,
-    makeHeaderWithAdditionalColumns
+    makeHeaderWithAdditionalColumns,
+    parseJannoRowFromNamedRecord
 ) where
 
 import           Poseidon.ColumnTypesJanno
@@ -40,6 +41,7 @@ import           Data.List                            (elemIndex, foldl',
                                                        intercalate, nub, sort,
                                                        transpose, (\\))
 import           Data.Maybe                           (catMaybes, fromJust)
+import qualified Data.Set                             as S
 import qualified Data.Text                            as T
 import qualified Data.Vector                          as V
 import           Generics.SOP.TH                      (deriveGeneric)
@@ -167,54 +169,56 @@ jannoHeaderString = map Bchs.unpack jannoHeader
 jannoRefHashMap :: HM.HashMap Bchs.ByteString ()
 jannoRefHashMap = HM.fromList $ map (\x -> (x, ())) jannoHeader
 
-instance Csv.FromNamedRecord JannoRow where
-    parseNamedRecord m = JannoRow
+-- instance Csv.FromNamedRecord JannoRow where
+--     parseNamedRecord m = JannoRow
+parseJannoRowFromNamedRecord :: S.Set Bchs.ByteString -> Csv.NamedRecord -> Csv.Parser JannoRow
+parseJannoRowFromNamedRecord mandatory m = JannoRow
         <$> filterLookup         m "Poseidon_ID"
         <*> filterLookup         m "Genetic_Sex"
         <*> filterLookup         m "Group_Name"
-        <*> filterLookupOptional m "Alternative_IDs"
-        <*> filterLookupOptional m "Relation_To"
-        <*> filterLookupOptional m "Relation_Degree"
-        <*> filterLookupOptional m "Relation_Type"
-        <*> filterLookupOptional m "Relation_Note"
-        <*> filterLookupOptional m "Collection_ID"
-        <*> filterLookupOptional m "Country"
-        <*> filterLookupOptional m "Country_ISO"
-        <*> filterLookupOptional m "Location"
-        <*> filterLookupOptional m "Site"
-        <*> filterLookupOptional m "Latitude"
-        <*> filterLookupOptional m "Longitude"
-        <*> filterLookupOptional m "Date_Type"
-        <*> filterLookupOptional m "Date_C14_Labnr"
-        <*> filterLookupOptional m "Date_C14_Uncal_BP"
-        <*> filterLookupOptional m "Date_C14_Uncal_BP_Err"
-        <*> filterLookupOptional m "Date_BC_AD_Start"
-        <*> filterLookupOptional m "Date_BC_AD_Median"
-        <*> filterLookupOptional m "Date_BC_AD_Stop"
-        <*> filterLookupOptional m "Date_Note"
-        <*> filterLookupOptional m "MT_Haplogroup"
-        <*> filterLookupOptional m "Y_Haplogroup"
-        <*> filterLookupOptional m "Source_Tissue"
-        <*> filterLookupOptional m "Nr_Libraries"
-        <*> filterLookupOptional m "Library_Names"
-        <*> filterLookupOptional m "Capture_Type"
-        <*> filterLookupOptional m "UDG"
-        <*> filterLookupOptional m "Library_Built"
-        <*> filterLookupOptional m "Genotype_Ploidy"
-        <*> filterLookupOptional m "Data_Preparation_Pipeline_URL"
-        <*> filterLookupOptional m "Endogenous"
-        <*> filterLookupOptional m "Nr_SNPs"
-        <*> filterLookupOptional m "Coverage_on_Target_SNPs"
-        <*> filterLookupOptional m "Damage"
-        <*> filterLookupOptional m "Contamination"
-        <*> filterLookupOptional m "Contamination_Err"
-        <*> filterLookupOptional m "Contamination_Meas"
-        <*> filterLookupOptional m "Contamination_Note"
-        <*> filterLookupOptional m "Genetic_Source_Accession_IDs"
-        <*> filterLookupOptional m "Primary_Contact"
-        <*> filterLookupOptional m "Publication"
-        <*> filterLookupOptional m "Note"
-        <*> filterLookupOptional m "Keywords"
+        <*> filterLookupOptional mandatory m "Alternative_IDs"
+        <*> filterLookupOptional mandatory m "Relation_To"
+        <*> filterLookupOptional mandatory m "Relation_Degree"
+        <*> filterLookupOptional mandatory m "Relation_Type"
+        <*> filterLookupOptional mandatory m "Relation_Note"
+        <*> filterLookupOptional mandatory m "Collection_ID"
+        <*> filterLookupOptional mandatory m "Country"
+        <*> filterLookupOptional mandatory m "Country_ISO"
+        <*> filterLookupOptional mandatory m "Location"
+        <*> filterLookupOptional mandatory m "Site"
+        <*> filterLookupOptional mandatory m "Latitude"
+        <*> filterLookupOptional mandatory m "Longitude"
+        <*> filterLookupOptional mandatory m "Date_Type"
+        <*> filterLookupOptional mandatory m "Date_C14_Labnr"
+        <*> filterLookupOptional mandatory m "Date_C14_Uncal_BP"
+        <*> filterLookupOptional mandatory m "Date_C14_Uncal_BP_Err"
+        <*> filterLookupOptional mandatory m "Date_BC_AD_Start"
+        <*> filterLookupOptional mandatory m "Date_BC_AD_Median"
+        <*> filterLookupOptional mandatory m "Date_BC_AD_Stop"
+        <*> filterLookupOptional mandatory m "Date_Note"
+        <*> filterLookupOptional mandatory m "MT_Haplogroup"
+        <*> filterLookupOptional mandatory m "Y_Haplogroup"
+        <*> filterLookupOptional mandatory m "Source_Tissue"
+        <*> filterLookupOptional mandatory m "Nr_Libraries"
+        <*> filterLookupOptional mandatory m "Library_Names"
+        <*> filterLookupOptional mandatory m "Capture_Type"
+        <*> filterLookupOptional mandatory m "UDG"
+        <*> filterLookupOptional mandatory m "Library_Built"
+        <*> filterLookupOptional mandatory m "Genotype_Ploidy"
+        <*> filterLookupOptional mandatory m "Data_Preparation_Pipeline_URL"
+        <*> filterLookupOptional mandatory m "Endogenous"
+        <*> filterLookupOptional mandatory m "Nr_SNPs"
+        <*> filterLookupOptional mandatory m "Coverage_on_Target_SNPs"
+        <*> filterLookupOptional mandatory m "Damage"
+        <*> filterLookupOptional mandatory m "Contamination"
+        <*> filterLookupOptional mandatory m "Contamination_Err"
+        <*> filterLookupOptional mandatory m "Contamination_Meas"
+        <*> filterLookupOptional mandatory m "Contamination_Note"
+        <*> filterLookupOptional mandatory m "Genetic_Source_Accession_IDs"
+        <*> filterLookupOptional mandatory m "Primary_Contact"
+        <*> filterLookupOptional mandatory m "Publication"
+        <*> filterLookupOptional mandatory m "Note"
+        <*> filterLookupOptional mandatory m "Keywords"
         -- beyond that read everything that is not in the set of defined variables
         -- as a separate hashmap
         <*> pure (CsvNamedRecord (m `HM.difference` jannoRefHashMap))
@@ -412,7 +416,7 @@ findSimilarNames reference = map (findSimilar reference)
 -- | A function to load one row of a janno file
 readJannoFileRow :: FilePath -> (Int, Bch.ByteString) -> PoseidonIO (Either PoseidonException JannoRow)
 readJannoFileRow jannoPath (lineNumber, row) = do
-    let decoded = Csv.decodeByNameWith decodingOptions row
+    let decoded = Csv.decodeByNameWithP (parseJannoRowFromNamedRecord S.empty) decodingOptions row
         simplifiedDecoded = (\(_,rs) -> V.head rs) <$> decoded
     case simplifiedDecoded of
         Left e -> do


### PR DESCRIPTION
I had an idea how to implement the optional completeness check for .janno and .ssf columns we discussed in the context of https://github.com/poseidon-framework/poseidon-schema/pull/109

cassava's [`decodeByNameWithP`](https://hackage-content.haskell.org/package/cassava-0.5.4.1/docs/Data-Csv.html#v:decodeByNameWith) allows to use a custom parser function of type `(NamedRecord -> Parser a)`, instead of requiring an instance of `FromNamedRecord`. That means we're free from the limitations of [`parseNamedRecord`](https://hackage-content.haskell.org/package/cassava-0.5.4.1/docs/Data-Csv.html#v:parseNamedRecord). Would have been good to know this earlier...